### PR TITLE
Added ability to assemble query strings for MicroCms image API in View.

### DIFF
--- a/config/vendor/view.php
+++ b/config/vendor/view.php
@@ -16,6 +16,7 @@ use Takemo101\CmsTool\Support\Accessor\SiteMetaAccessor;
 use Takemo101\CmsTool\Support\Twig\AssetExtension;
 use Takemo101\CmsTool\Support\Twig\ErrorExtension;
 use Takemo101\CmsTool\Support\Twig\FlashExtension;
+use Takemo101\CmsTool\Support\Twig\MicroCmsExtension;
 use Takemo101\CmsTool\Support\Twig\OldExtension;
 use Takemo101\CmsTool\Support\Twig\SessionExtension;
 use Takemo101\CmsTool\Support\Twig\TranslationExtension;
@@ -102,6 +103,7 @@ return [
             SessionExtension::class,
             AssetExtension::class,
             TranslationExtension::class,
+            MicroCmsExtension::class,
         ],
 
         // Set up functions to be used in Twig

--- a/resources/themes/simply/README.md
+++ b/resources/themes/simply/README.md
@@ -26,9 +26,9 @@
     // tags テーマのタグ配列：任意
     "tags": ["ブログ", "シンプル", "ミニマル"],
     // link テーマの詳細説明が記載されているサイトのリンク：任意
-    "link": "https://github.com/takemo101/chubby",
+    "link": "https://github.com/takemo101/cms-tool",
     // preset テーマで利用するプリセットラベル：任意
-    "preset": "blog",
+    "preset": "microcms:blog",
     // author テーマ作者情報：必須
     "author": {
         // name テーマ作者名：必須

--- a/resources/themes/simply/templates/components/contents.twig
+++ b/resources/themes/simply/templates/components/contents.twig
@@ -18,7 +18,7 @@
                         class="object-cover
                             xl:w-[280px] sm:w-[200px] w-full
                             xl:h-[280px] sm:h-[200px] h-full"
-                        src="{{ content.eyecatch ? content.eyecatch.url : asset('empty.jpeg') }}" />
+                        src="{{ content.eyecatch ? microcms_img(content.eyecatch.url, { w: 600 }) : asset('empty.jpeg') }}" />
                 </a>
             </div>
             <div class="flex items-center">

--- a/resources/themes/simply/templates/components/home/contents.twig
+++ b/resources/themes/simply/templates/components/home/contents.twig
@@ -31,7 +31,7 @@
                             alt="{{ content.title }}"
                             class="object-cover
                                 w-full xl:h-[380px] sm:h-[280px] h-full"
-                            src="{{ content.eyecatch ? content.eyecatch.url : asset('empty.jpeg') }}" />
+                            src="{{ content.eyecatch ? microcms_img(content.eyecatch.url, { w: 600 }) : asset('empty.jpeg') }}" />
                     </div>
                     <p class="text-lg font-bold mb-4">
                         {{ content.title }}

--- a/resources/themes/simply/templates/pages/home.twig
+++ b/resources/themes/simply/templates/pages/home.twig
@@ -15,7 +15,7 @@
                 alt="{{ first_content.title }}"
                 class="object-cover
                     w-full xl:h-[580px] sm:h-[480px] h-[380px]"
-                src="{{ first_content.eyecatch ? first_content.eyecatch.url : asset('empty.jpeg') }}" />
+                src="{{ first_content.eyecatch ? microcms_img(first_content.eyecatch.url, { w: 1000 }) : asset('empty.jpeg') }}" />
             <div class="bg-black text-white">
                 <div class="container mx-auto px-4">
                     <div class="flex items-center">

--- a/src/Infra/MicroCms/MicroCmsImageApiQueryBuilder.php
+++ b/src/Infra/MicroCms/MicroCmsImageApiQueryBuilder.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Takemo101\CmsTool\Infra\MicroCms;
+
+use Takemo101\CmsTool\Support\Shared\ImmutableArrayObject;
+
+class MicroCmsImageApiQueryBuilder
+{
+    /**
+     * @param string|null $url
+     * @param array<string,mixed> $params
+     * @return string|null
+     */
+    public function build(?string $url, array $params = []): ?string
+    {
+        if (empty($url)) {
+            return null;
+        }
+
+        $object = ImmutableArrayObject::of($params);
+
+        $query = array_filter([
+            ...$this->buildSizeQuery($object),
+            ...$this->buildQualityQuery($object),
+            ...$this->buildFormatQuery($object),
+            ...$this->buildDprQuery($object),
+        ]);
+
+        return $url . (
+            empty($query)
+            ? ''
+            : '?' . http_build_query($query)
+        );
+    }
+
+    /**
+     * @param ImmutableArrayObject $object
+     * @return array<string,mixed>
+     */
+    private function buildSizeQuery(ImmutableArrayObject $object): array
+    {
+        return [
+            'w' => $object->get(
+                'w',
+                $object->get('width'),
+            ),
+            'h' => $object->get(
+                'h',
+                $object->get('height'),
+            ),
+            'f' => $object->get(
+                'f',
+                $object->get('fit'),
+            ),
+        ];
+    }
+
+    /**
+     * @param ImmutableArrayObject $object
+     * @return array<string,mixed>
+     */
+    private function buildQualityQuery(ImmutableArrayObject $object): array
+    {
+        return [
+            'q' => $object->get(
+                'q',
+                $object->get('quality'),
+            ),
+        ];
+    }
+
+    /**
+     * @param ImmutableArrayObject $object
+     * @return array<string,mixed>
+     */
+    private function buildFormatQuery(ImmutableArrayObject $object): array
+    {
+        return [
+            'fm' => $object->get(
+                'fm',
+                $object->get('format'),
+            ),
+        ];
+    }
+
+    private function buildDprQuery(ImmutableArrayObject $object): array
+    {
+        return [
+            'dpr' => $object->get('dpr'),
+        ];
+    }
+}

--- a/src/Infra/Saloon/Validator/SaloonMicroCmsApiAccessValidator.php
+++ b/src/Infra/Saloon/Validator/SaloonMicroCmsApiAccessValidator.php
@@ -4,7 +4,6 @@ namespace Takemo101\CmsTool\Infra\Saloon\Validator;
 
 use Takemo101\CmsTool\Domain\MicroCms\MicroCmsApi;
 use Takemo101\CmsTool\Domain\MicroCms\MicroCmsApiAccessValidator;
-use Takemo101\CmsTool\Infra\Saloon\HttpClient\MicroCmsApiConnector;
 use Takemo101\CmsTool\Infra\Saloon\HttpClient\MicroCmsApiConnectorFactory;
 use Takemo101\CmsTool\Infra\Saloon\HttpClient\Ping\MicroCmsPingRequest;
 use Takemo101\CmsTool\Infra\Saloon\HttpClient\Ping\MicroCmsPingResponse;

--- a/src/Support/Twig/MicroCmsExtension.php
+++ b/src/Support/Twig/MicroCmsExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Takemo101\CmsTool\Support\Twig;
+
+use Takemo101\CmsTool\Infra\MicroCms\MicroCmsImageApiQueryBuilder;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+class MicroCmsExtension extends AbstractExtension
+{
+    /**
+     * constructor
+     *
+     * @param MicroCmsImageApiQueryBuilder $builder
+     */
+    public function __construct(
+        private MicroCmsImageApiQueryBuilder $builder,
+    ) {
+        //
+    }
+
+    /**
+     * @return TwigFunction[]
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('microcms_img', [$this->builder, 'build']),
+        ];
+    }
+}

--- a/tests/Infra/MicroCms/MicroCmsImageApiQueryBuilderTest.php
+++ b/tests/Infra/MicroCms/MicroCmsImageApiQueryBuilderTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use Takemo101\CmsTool\Infra\MicroCms\MicroCmsImageApiQueryBuilder;
+
+describe(
+    'MicroCmsImageApiQueryBuilder',
+    function () {
+
+        it('should return null when the URL is empty', function () {
+            $builder = new MicroCmsImageApiQueryBuilder();
+
+            $result = $builder->build(null);
+
+            expect($result)->toBeNull();
+        });
+
+        it('should build the query string with the provided parameters', function () {
+            $builder = new MicroCmsImageApiQueryBuilder();
+
+            $url = 'https://example.com/image.jpg';
+            $params = [
+                'w' => 500,
+                'h' => 300,
+                'q' => 80,
+                'fm' => 'jpg',
+                'dpr' => 2,
+            ];
+
+            $result = $builder->build($url, $params);
+
+            expect($result)->toBe('https://example.com/image.jpg?w=500&h=300&q=80&fm=jpg&dpr=2');
+        });
+
+        it('should build the query string with default values for missing parameters', function () {
+            $builder = new MicroCmsImageApiQueryBuilder();
+
+            $url = 'https://example.com/image.jpg';
+            $params = [
+                'w' => 500,
+                'q' => 80,
+            ];
+
+            $result = $builder->build($url, $params);
+
+            expect($result)->toBe('https://example.com/image.jpg?w=500&q=80');
+        });
+
+        it('should return null when the URL is empty even with parameters', function () {
+            $builder = new MicroCmsImageApiQueryBuilder();
+
+            $params = [
+                'w' => 500,
+                'h' => 300,
+            ];
+
+            $result = $builder->build(null, $params);
+
+            expect($result)->toBeNull();
+        });
+
+        it('should return null when no parameters are provided', function () {
+            $builder = new MicroCmsImageApiQueryBuilder();
+
+            $url = 'https://example.com/image.jpg';
+
+            $result = $builder->build($url);
+
+            expect($result)->toBe('https://example.com/image.jpg');
+        });
+
+        it('should return null when the URL is empty and no parameters are provided', function () {
+            $builder = new MicroCmsImageApiQueryBuilder();
+
+            $result = $builder->build(null);
+
+            expect($result)->toBeNull();
+        });
+
+        it('should build the query string with custom parameter names', function () {
+            $builder = new MicroCmsImageApiQueryBuilder();
+
+            $url = 'https://example.com/image.jpg';
+            $params = [
+                'width' => 500,
+                'height' => 300,
+                'quality' => 80,
+                'format' => 'jpg',
+                'dpr' => 2,
+            ];
+
+            $result = $builder->build($url, $params);
+
+            expect($result)->toBe('https://example.com/image.jpg?w=500&h=300&q=80&fm=jpg&dpr=2');
+        });
+    }
+)->group('MicroCmsImageApiQueryBuilder', 'infra');


### PR DESCRIPTION
## Overview
Added class ``MicroCmsImageApiQueryBuilder`` to assemble query strings for the MicroCms image API in View.

## Changes
1. add the ``MicroCmsImageApiQueryBuilder`` class
2. added ``MicroCmsExtension`` to get the query-assigned URL of the image API from the image URL on the View

## Remarks
You can use the ``microcms_img`` Twig function to get URLs with image API queries