### PR TITLE
Added ability to edit robots.txt.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 /storage                export-ignore
 /docker                 export-ignore
 /themes                 export-ignore
+/public                 export-ignore
 /.github                export-ignore
 /.php_cs                export-ignore
 .editorconfig           export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /storage/public/*
 /storage/dump/*
 /public/storage
+/public/robots.txt
 /themes/*
 /.env
 /setting.json

--- a/config/system.php
+++ b/config/system.php
@@ -35,4 +35,11 @@ return [
             : null,
         RequestOptions::TIMEOUT => 60, // default: 30
     ],
+
+    // Settings for robots.txt
+    'robots_txt' => [
+
+        // Path to robots.txt
+        'path' => base_path('public', 'robots.txt'),
+    ]
 ];

--- a/resources/txt/robots.txt
+++ b/resources/txt/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/resources/views/components/sidebar.twig
+++ b/resources/views/components/sidebar.twig
@@ -25,6 +25,10 @@
                 label: 'トラッキングコード',
                 route: 'admin.tracking.edit',
             },
+            robots: {
+                label: 'robots.txt',
+                route: 'admin.robots.edit',
+            },
             theme: {
                 label: 'テーマ',
                 route: 'admin.theme.index',

--- a/resources/views/robots/edit.twig
+++ b/resources/views/robots/edit.twig
@@ -1,0 +1,51 @@
+{% extends 'cms-tool::layouts.dashboard' %}
+
+{% block title %}robots.txt編集{% endblock %}
+
+{% block current %}robots{% endblock %}
+
+{% import "cms-tool::components.forms" as forms %}
+{% import "cms-tool::components.alerts" as alerts %}
+{% import "cms-tool::components.dialogs" as dialogs %}
+
+{% block content_right %}
+<div class="card">
+    <div class="card-header">
+        <h2 class="card-header__title">robots.txt編集</h2>
+        <hr class="divider" />
+    </div>
+    <div class="card-body" x-data="{ open: false }">
+        {{ alerts.error() }}
+
+        {{ form_open({
+            route: 'admin.robots.update',
+            method: 'put',
+            'x-ref': 'form',
+        }) }}
+            <div class="mb:30">
+                <div class="form-column">
+                    {{ forms.textarea({
+                        name: 'content',
+                        label:'robots.txt',
+                        value: content,
+                        rows: 20,
+                        hint: 'robots.txtはbotがサイトをクロールする際に参照するファイルで、検索エンジンにインデックスされたくないページがある場合は、ここに設定を記述してください。',
+                    }) }}
+                </div>
+            </div>
+            <div class="t:right">
+                {{ forms.button({
+                    label: '更新',
+                    class: 'form-btn--primary',
+                    click: '$refs.form.reportValidity() && (open = true)',
+                }) }}
+            </div>
+        {{ form_close() }}
+        {{ dialogs.confirm({
+            title: 'Update',
+            message: '変更内容を保存しますか？',
+            submit: '$refs.form.submit()',
+        }) }}
+    </div>
+</div>
+{% endblock %}

--- a/src/Http/Controller/Admin/RobotsTxtController.php
+++ b/src/Http/Controller/Admin/RobotsTxtController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Takemo101\CmsTool\Http\Controller\Admin;
+
+use CmsTool\Support\Validation\HttpValidationErrorException;
+use CmsTool\Support\Validation\RequestValidator;
+use CmsTool\View\View;
+use Psr\Http\Message\ServerRequestInterface;
+use Takemo101\CmsTool\Http\Renderer\RedirectBackRenderer;
+use Takemo101\CmsTool\Http\Request\Admin\SaveRobotsTxtRequest;
+use Takemo101\CmsTool\Infra\Storage\Repository\RobotsTxtRepository;
+
+class RobotsTxtController
+{
+    /**
+     * @param RobotsTxtRepository $repository
+     * @return View
+     */
+    public function edit(
+        RobotsTxtRepository $repository,
+    ): View {
+        $content = $repository->get();
+
+        return view(
+            'cms-tool::robots.edit',
+            compact('content'),
+        );
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param RequestValidator $validator
+     * @param RobotsTxtRepository $repository
+     * @return RedirectBackRenderer
+     * @throws HttpValidationErrorException
+     */
+    public function update(
+        ServerRequestInterface $request,
+        RequestValidator $validator,
+        RobotsTxtRepository $repository,
+    ): RedirectBackRenderer {
+        $form = $validator->throwIfFailed(
+            $request,
+            SaveRobotsTxtRequest::class,
+        );
+
+        $repository->save($form->content);
+
+        return redirect()->back();
+    }
+}

--- a/src/Http/Controller/Admin/UninstallController.php
+++ b/src/Http/Controller/Admin/UninstallController.php
@@ -4,7 +4,9 @@ namespace Takemo101\CmsTool\Http\Controller\Admin;
 
 use CmsTool\View\View;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Takemo101\Chubby\Http\Renderer\RouteRedirectRenderer;
+use Takemo101\CmsTool\Infra\Event\Uninstalled;
 use Takemo101\CmsTool\UseCase\Admin\Auth\AdminSession;
 use Takemo101\CmsTool\UseCase\Install\Handler\UninstallHandler;
 
@@ -25,6 +27,7 @@ class UninstallController
         UninstallHandler $handler,
         AdminSession $session,
         CacheItemPoolInterface $cache,
+        EventDispatcherInterface $dispatcher
     ): RouteRedirectRenderer {
 
         $handler->handle();
@@ -32,6 +35,8 @@ class UninstallController
         $cache->clear();
 
         $session->logout();
+
+        $dispatcher->dispatch(new Uninstalled());
 
         return redirect()->route('home');
     }

--- a/src/Http/Controller/InstallController.php
+++ b/src/Http/Controller/InstallController.php
@@ -5,6 +5,7 @@ namespace Takemo101\CmsTool\Http\Controller;
 use CmsTool\Support\Validation\HttpValidationErrorException;
 use CmsTool\Support\Validation\RequestValidator;
 use CmsTool\View\View;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Takemo101\Chubby\Http\Renderer\RouteRedirectRenderer;
 use Takemo101\CmsTool\Domain\Install\InstallationNotPossibleException;
@@ -12,6 +13,7 @@ use Takemo101\CmsTool\Domain\MicroCms\MicroCmsApiAccessException;
 use Takemo101\CmsTool\Http\Request\Install\SaveMicroCmsApiRequest;
 use Takemo101\CmsTool\Http\Request\Install\SaveBasicSettingRequest;
 use Takemo101\CmsTool\Http\ViewModel\InstallPage;
+use Takemo101\CmsTool\Infra\Event\Installed;
 use Takemo101\CmsTool\UseCase\BasicSetting\Handler\RootAdminForSaveBasicSettingCommand;
 use Takemo101\CmsTool\UseCase\BasicSetting\Handler\SaveBasicSettingCommand;
 use Takemo101\CmsTool\UseCase\BasicSetting\Handler\SaveBasicSettingHandler;
@@ -159,6 +161,7 @@ class InstallController
     public function install(
         ServerRequestInterface $request,
         InstallHandler $handler,
+        EventDispatcherInterface $dispatcher,
     ): RouteRedirectRenderer {
         try {
             $handler->handle();
@@ -172,6 +175,8 @@ class InstallController
                 request: $request,
             );
         }
+
+        $dispatcher->dispatch(new Installed());
 
         return redirect()->route('admin.login');
     }

--- a/src/Http/Request/Admin/SaveRobotsTxtRequest.php
+++ b/src/Http/Request/Admin/SaveRobotsTxtRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Takemo101\CmsTool\Http\Request\Admin;
+
+use Symfony\Component\Validator\Constraints\Length;
+
+readonly class SaveRobotsTxtRequest
+{
+    /**
+     * constructor
+     *
+     * @param string $content
+     */
+    public function __construct(
+        #[Length(max: 10000)]
+        public string $content,
+    ) {
+        //
+    }
+}

--- a/src/Infra/Event/Installed.php
+++ b/src/Infra/Event/Installed.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Takemo101\CmsTool\Infra\Event;
+
+use Takemo101\Chubby\Event\StoppableEvent;
+
+class Installed extends StoppableEvent
+{
+    //
+}

--- a/src/Infra/Event/Uninstalled.php
+++ b/src/Infra/Event/Uninstalled.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Takemo101\CmsTool\Infra\Event;
+
+use Takemo101\Chubby\Event\StoppableEvent;
+
+class Uninstalled extends StoppableEvent
+{
+    //
+}

--- a/src/Infra/Listener/CreateRobotsTxtListener.php
+++ b/src/Infra/Listener/CreateRobotsTxtListener.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Takemo101\CmsTool\Infra\Listener;
+
+use Takemo101\Chubby\Event\Attribute\AsEventListener;
+use Takemo101\Chubby\Filesystem\LocalFilesystem;
+use Takemo101\CmsTool\Infra\Event\Installed;
+use Takemo101\CmsTool\Infra\Storage\Repository\RobotsTxtRepository;
+use Takemo101\CmsTool\Support\VendorPath;
+
+#[AsEventListener(Installed::class)]
+class CreateRobotsTxtListener
+{
+    /**
+     * constructor
+     *
+     * @param LocalFilesystem $filesystem
+     * @param RobotsTxtRepository $repository
+     * @param VendorPath $path
+     */
+    public function __construct(
+        private LocalFilesystem $filesystem,
+        private RobotsTxtRepository $repository,
+        private VendorPath $path,
+    ) {
+        //
+    }
+
+    /**
+     * @return void
+     */
+    public function __invoke(): void
+    {
+        $content = $this->filesystem->read(
+            $this->path->getResourcePath('txt', 'robots.txt'),
+        );
+
+        $this->repository->save($content);
+    }
+}

--- a/src/Infra/Listener/DeleteRobotsTxtListener.php
+++ b/src/Infra/Listener/DeleteRobotsTxtListener.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Takemo101\CmsTool\Infra\Listener;
+
+use Takemo101\Chubby\Event\Attribute\AsEventListener;
+use Takemo101\CmsTool\Infra\Event\Uninstalled;
+use Takemo101\CmsTool\Infra\Storage\Repository\RobotsTxtRepository;
+
+#[AsEventListener(Uninstalled::class)]
+class DeleteRobotsTxtListener
+{
+    /**
+     * constructor
+     *
+     * @param RobotsTxtRepository $repository
+     */
+    public function __construct(
+        private RobotsTxtRepository $repository,
+    ) {
+        //
+    }
+
+    /**
+     * @return void
+     */
+    public function __invoke(): void
+    {
+        $this->repository->delete();
+    }
+}

--- a/src/Infra/Storage/Repository/RobotsTxtRepository.php
+++ b/src/Infra/Storage/Repository/RobotsTxtRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Takemo101\CmsTool\Infra\Storage\Repository;
+
+use DI\Attribute\Inject;
+use Takemo101\Chubby\Filesystem\LocalFilesystem;
+
+class RobotsTxtRepository
+{
+    /**
+     * constructor
+     *
+     * @param LocalFilesystem $filesystem
+     * @param string $path
+     */
+    public function __construct(
+        private LocalFilesystem $filesystem,
+        #[Inject('config.system.robots_txt.path')]
+        private string $path = 'robots.txt',
+    ) {
+    }
+
+    /**
+     * Get robots.txt content
+     *
+     * @return string|null
+     */
+    public function get(): ?string
+    {
+        return $this->filesystem->read($this->path);
+    }
+
+    /**
+     * Save robots.txt content
+     *
+     * @param string $content
+     * @return void
+     */
+    public function save(string $content): void
+    {
+        $this->filesystem->write($this->path, $content);
+    }
+
+    /**
+     * Delete robots.txt
+     *
+     * @return void
+     */
+    public function delete(): void
+    {
+        $this->filesystem->delete($this->path);
+    }
+}

--- a/src/Infra/Storage/Repository/RobotsTxtRepository.php
+++ b/src/Infra/Storage/Repository/RobotsTxtRepository.php
@@ -48,6 +48,8 @@ class RobotsTxtRepository
      */
     public function delete(): void
     {
-        $this->filesystem->delete($this->path);
+        if ($this->filesystem->exists($this->path)) {
+            $this->filesystem->delete($this->path);
+        }
     }
 }

--- a/src/function.php
+++ b/src/function.php
@@ -32,6 +32,7 @@ use Takemo101\CmsTool\Http\Controller\Admin\CacheController;
 use Takemo101\CmsTool\Http\Controller\Admin\DashboardController;
 use Takemo101\CmsTool\Http\Controller\Admin\LoginController;
 use Takemo101\CmsTool\Http\Controller\Admin\MicroCmsApiController;
+use Takemo101\CmsTool\Http\Controller\Admin\RobotsTxtController;
 use Takemo101\CmsTool\Http\Controller\Admin\SiteMetaController;
 use Takemo101\CmsTool\Http\Controller\Admin\SiteSeoController;
 use Takemo101\CmsTool\Http\Controller\Admin\ThemeController;
@@ -242,6 +243,15 @@ hook()
                                         '/tracking-code',
                                         [TrackingCodeController::class, 'update'],
                                     )->setName('admin.tracking.update');
+
+                                    $proxy->get(
+                                        '/robots-txt',
+                                        [RobotsTxtController::class, 'edit'],
+                                    )->setName('admin.robots.edit');
+                                    $proxy->put(
+                                        '/robots-txt',
+                                        [RobotsTxtController::class, 'update'],
+                                    )->setName('admin.robots.update');
 
                                     $proxy->patch(
                                         '/publish/{status:published|unpublished}',

--- a/src/function.php
+++ b/src/function.php
@@ -47,7 +47,9 @@ use Takemo101\CmsTool\Http\Middleware\WhenUninstalled;
 use Takemo101\CmsTool\Http\Middleware\WhenUnpublished;
 use Takemo101\CmsTool\Infra\Listener\AdminSessionContextSetupListener;
 use Takemo101\CmsTool\Infra\Listener\ApplicationUrlReplaceListener;
+use Takemo101\CmsTool\Infra\Listener\CreateRobotsTxtListener;
 use Takemo101\CmsTool\Infra\Listener\CsrfGuardContextSetupListener;
+use Takemo101\CmsTool\Infra\Listener\DeleteRobotsTxtListener;
 use Takemo101\CmsTool\Infra\Listener\RequestParameterSetupListener;
 use Takemo101\CmsTool\Infra\Listener\ServerRequestAccessorSetupListener;
 use Takemo101\CmsTool\Infra\Listener\TwigExtensionSetupListener;
@@ -67,7 +69,9 @@ hook()
             ->on(RequestParameterSetupListener::class)
             ->on(TwigExtensionSetupListener::class)
             ->on(ApplicationUrlReplaceListener::class)
-            ->on(ServerRequestAccessorSetupListener::class),
+            ->on(ServerRequestAccessorSetupListener::class)
+            ->on(CreateRobotsTxtListener::class)
+            ->on(DeleteRobotsTxtListener::class),
     )
     ->onTyped(
         function (

--- a/tests/Infra/Storage/RobotsTxtRepositoryTest.php
+++ b/tests/Infra/Storage/RobotsTxtRepositoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Takemo101\Chubby\Filesystem\LocalFilesystem;
+use Takemo101\CmsTool\Infra\Storage\Repository\RobotsTxtRepository;
+use Mockery as m;
+
+describe(
+    'RobotsTxtRepository',
+    function () {
+        it('should get robots.txt content', function () {
+            // Create a mock for the LocalFilesystem
+            $filesystem = m::mock(LocalFilesystem::class);
+            $filesystem->shouldReceive('read')->once()->andReturn('User-agent: *');
+
+            // Create an instance of the RobotsTxtRepository
+            $repository = new RobotsTxtRepository($filesystem);
+
+            // Call the get method
+            $content = $repository->get();
+
+            // Assert that the content is correct
+            expect($content)->toBe('User-agent: *');
+        });
+
+        it('should save robots.txt content', function () {
+            // Create a mock for the LocalFilesystem
+            $filesystem = m::mock(LocalFilesystem::class);
+            $filesystem->shouldReceive('write')->once();
+
+            // Create an instance of the RobotsTxtRepository
+            $repository = new RobotsTxtRepository($filesystem);
+
+            // Call the save method
+            $repository->save('User-agent: *');
+
+            // Assert that the write method was called with the correct arguments
+            $filesystem->shouldHaveReceived('write')->with('robots.txt', 'User-agent: *');
+        });
+
+        it('should delete robots.txt', function () {
+            // Create a mock for the LocalFilesystem
+            $filesystem = m::mock(LocalFilesystem::class);
+            $filesystem->shouldReceive('delete')->once();
+
+            // Create an instance of the RobotsTxtRepository
+            $repository = new RobotsTxtRepository($filesystem);
+
+            // Call the delete method
+            $repository->delete();
+
+            // Assert that the delete method was called with the correct arguments
+            $filesystem->shouldHaveReceived('delete')->with('robots.txt');
+        });
+    }
+)->group('infra', 'RobotsTxtRepository');

--- a/tests/Infra/Storage/RobotsTxtRepositoryTest.php
+++ b/tests/Infra/Storage/RobotsTxtRepositoryTest.php
@@ -40,6 +40,7 @@ describe(
         it('should delete robots.txt', function () {
             // Create a mock for the LocalFilesystem
             $filesystem = m::mock(LocalFilesystem::class);
+            $filesystem->shouldReceive('exists')->once()->andReturn(true);
             $filesystem->shouldReceive('delete')->once();
 
             // Create an instance of the RobotsTxtRepository


### PR DESCRIPTION
## Overview
Added ability to edit robots.txt.
As soon as the installation is completed, a ``robots.txt`` is generated in the ``public`` directory and the generated files are deleted when the installation is uninstalled.

## Changes
1. add ``Installed`` and ``Uninstalled`` events
2. add ``CreateRobotsTxtListener`` and ``DeleteRobotsTxtListener`` classes, which are listener classes for 1.
3. add ``RobotsTxtRepository`` class to persist robots.txt
4. added robots.txt edit screen