### PR TITLE
The cache is now cleared when the theme is activated.

### DIFF
--- a/src/Infra/Event/ThemeActivated.php
+++ b/src/Infra/Event/ThemeActivated.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Takemo101\CmsTool\Infra\Event;
+
+use CmsTool\Theme\ThemeId;
+use Takemo101\Chubby\Event\StoppableEvent;
+
+class ThemeActivated extends StoppableEvent
+{
+    /**
+     * constructor
+     *
+     * @param ThemeId $activeThemeId
+     */
+    public function __construct(
+        private ThemeId $activeThemeId,
+    ) {
+        //
+    }
+
+    /**
+     * Theme before change
+     *
+     * @return ThemeId
+     */
+    public function getActiveThemeId(): ThemeId
+    {
+        return $this->activeThemeId;
+    }
+}

--- a/src/Infra/Listener/ClearCacheListener.php
+++ b/src/Infra/Listener/ClearCacheListener.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Takemo101\CmsTool\Infra\Listener;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Takemo101\Chubby\Event\Attribute\AsEventListener;
+use Takemo101\CmsTool\Infra\Event\ThemeActivated;
+
+#[AsEventListener(ThemeActivated::class)]
+class ClearCacheListener
+{
+    /**
+     * constructor
+     *
+     * @param CacheItemPoolInterface $cache
+     */
+    public function __construct(
+        private CacheItemPoolInterface $cache,
+    ) {
+        //
+    }
+
+    /**
+     * @return void
+     */
+    public function __invoke(): void
+    {
+        $this->cache->clear();
+    }
+}

--- a/src/function.php
+++ b/src/function.php
@@ -48,6 +48,7 @@ use Takemo101\CmsTool\Http\Middleware\WhenUninstalled;
 use Takemo101\CmsTool\Http\Middleware\WhenUnpublished;
 use Takemo101\CmsTool\Infra\Listener\AdminSessionContextSetupListener;
 use Takemo101\CmsTool\Infra\Listener\ApplicationUrlReplaceListener;
+use Takemo101\CmsTool\Infra\Listener\ClearCacheListener;
 use Takemo101\CmsTool\Infra\Listener\CreateRobotsTxtListener;
 use Takemo101\CmsTool\Infra\Listener\CsrfGuardContextSetupListener;
 use Takemo101\CmsTool\Infra\Listener\DeleteRobotsTxtListener;
@@ -72,7 +73,8 @@ hook()
             ->on(ApplicationUrlReplaceListener::class)
             ->on(ServerRequestAccessorSetupListener::class)
             ->on(CreateRobotsTxtListener::class)
-            ->on(DeleteRobotsTxtListener::class),
+            ->on(DeleteRobotsTxtListener::class)
+            ->on(ClearCacheListener::class),
     )
     ->onTyped(
         function (


### PR DESCRIPTION
## Overview
The cache is now cleared when the theme is activated.

## Changes
1. add a ``ThemeActivated`` event
2. added a ``ClearCacheListener`` class to clear the cache.
