### PR TITLE
Fixed handling of cases where robots.txt does not exist.

### DIFF
--- a/src/Infra/Storage/Repository/RobotsTxtRepository.php
+++ b/src/Infra/Storage/Repository/RobotsTxtRepository.php
@@ -27,7 +27,9 @@ class RobotsTxtRepository
      */
     public function get(): ?string
     {
-        return $this->filesystem->read($this->path);
+        return $this->filesystem->exists($this->path)
+            ? $this->filesystem->read($this->path)
+            : null;
     }
 
     /**

--- a/tests/Infra/Storage/RobotsTxtRepositoryTest.php
+++ b/tests/Infra/Storage/RobotsTxtRepositoryTest.php
@@ -10,6 +10,7 @@ describe(
         it('should get robots.txt content', function () {
             // Create a mock for the LocalFilesystem
             $filesystem = m::mock(LocalFilesystem::class);
+            $filesystem->shouldReceive('exists')->once()->andReturn(true);
             $filesystem->shouldReceive('read')->once()->andReturn('User-agent: *');
 
             // Create an instance of the RobotsTxtRepository
@@ -20,6 +21,21 @@ describe(
 
             // Assert that the content is correct
             expect($content)->toBe('User-agent: *');
+        });
+
+        it('should return null if robots.txt does not exist', function () {
+            // Create a mock for the LocalFilesystem
+            $filesystem = m::mock(LocalFilesystem::class);
+            $filesystem->shouldReceive('exists')->once()->andReturn(false);
+
+            // Create an instance of the RobotsTxtRepository
+            $repository = new RobotsTxtRepository($filesystem);
+
+            // Call the get method
+            $content = $repository->get();
+
+            // Assert that the content is null
+            expect($content)->toBeNull();
         });
 
         it('should save robots.txt content', function () {


### PR DESCRIPTION
## Overview
Errors occur if ``robots.txt`` does not exist, so modified the process to get ``null`` if it does not exist.
