### PR TITLE
テーマの入力スキーマ設定の修正

### DIFF
--- a/modules/theme/src/Schema/Setting/AbstractInputSetting.php
+++ b/modules/theme/src/Schema/Setting/AbstractInputSetting.php
@@ -19,11 +19,13 @@ abstract class AbstractInputSetting extends AbstractSetting
      *
      * @param SchemaSettingId $id
      * @param string $label
+     * @param string $hint
      * @param T|null $default
      */
     public function __construct(
         public readonly SchemaSettingId $id,
         public readonly string $label,
+        public readonly string $hint = '',
         mixed $default = null,
     ) {
         assert(

--- a/modules/theme/src/Schema/Setting/AbstractTextInputSetting.php
+++ b/modules/theme/src/Schema/Setting/AbstractTextInputSetting.php
@@ -17,18 +17,21 @@ abstract class AbstractTextInputSetting extends AbstractInputSetting
      *
      * @param SchemaSettingId $id
      * @param string $label
+     * @param string $hint
      * @param T|null $default
      * @param string|null $placeholder
      */
     public function __construct(
         SchemaSettingId $id,
         string $label,
+        string $hint = '',
         mixed $default = null,
         public readonly ?string $placeholder = null,
     ) {
         parent::__construct(
             id: $id,
             label: $label,
+            hint: $hint,
             default: $default,
         );
     }

--- a/modules/theme/src/Schema/Setting/CheckboxSetting.php
+++ b/modules/theme/src/Schema/Setting/CheckboxSetting.php
@@ -70,6 +70,7 @@ class CheckboxSetting extends AbstractInputSetting
         return [
             'id' => $this->id->value(),
             'label' => $this->label,
+            'hint' => $this->hint,
             'default' => $this->default,
         ];
     }
@@ -80,6 +81,7 @@ class CheckboxSetting extends AbstractInputSetting
      * @param array{
      *   id?: string,
      *   label?: string,
+     *   hint?: string,
      *   default?: boolean,
      * } $data
      * @throws ArrayKeyMissingException
@@ -89,6 +91,7 @@ class CheckboxSetting extends AbstractInputSetting
         return new self(
             id: new SchemaSettingId($data['id'] ?? ArrayKeyMissingException::throw('id')),
             label: $data['label'] ?? ArrayKeyMissingException::throw('label'),
+            hint: $data['hint'] ?? '',
             default: $data['default'] ?? null,
         );
     }

--- a/modules/theme/src/Schema/Setting/ColorSetting.php
+++ b/modules/theme/src/Schema/Setting/ColorSetting.php
@@ -30,11 +30,13 @@ class ColorSetting extends AbstractInputSetting
     public function __construct(
         SchemaSettingId $id,
         string $label,
+        string $hint = '',
         mixed $default = null,
     ) {
         parent::__construct(
             id: $id,
             label: $label,
+            hint: $hint,
             default: $default,
         );
 
@@ -62,6 +64,7 @@ class ColorSetting extends AbstractInputSetting
         return [
             'id' => $this->id->value(),
             'label' => $this->label,
+            'hint' => $this->hint,
             'default' => $this->default,
         ];
     }
@@ -72,6 +75,7 @@ class ColorSetting extends AbstractInputSetting
      * @param array{
      *   id?: string,
      *   label?: string,
+     *   hint?: string,
      *   default?: string,
      * } $data
      * @throws ArrayKeyMissingException
@@ -81,6 +85,7 @@ class ColorSetting extends AbstractInputSetting
         return new self(
             id: new SchemaSettingId($data['id'] ?? ArrayKeyMissingException::throw('id')),
             label: $data['label'] ?? ArrayKeyMissingException::throw('label'),
+            hint: $data['hint'] ?? '',
             default: $data['default'] ?? null,
         );
     }

--- a/modules/theme/src/Schema/Setting/EditorSetting.php
+++ b/modules/theme/src/Schema/Setting/EditorSetting.php
@@ -65,6 +65,7 @@ class EditorSetting extends AbstractInputSetting
         return [
             'id' => $this->id->value(),
             'label' => $this->label,
+            'hint' => $this->hint,
             'default' => $this->default,
         ];
     }
@@ -75,6 +76,7 @@ class EditorSetting extends AbstractInputSetting
      * @param array{
      *   id?: string,
      *   label?: string,
+     *   hint?: string,
      *   default?: string,
      * } $data
      */
@@ -83,6 +85,7 @@ class EditorSetting extends AbstractInputSetting
         return new self(
             id: new SchemaSettingId($data['id'] ?? ArrayKeyMissingException::throw('id')),
             label: $data['label'] ?? ArrayKeyMissingException::throw('label'),
+            hint: $data['hint'] ?? '',
             default: $data['default'] ?? null,
         );
     }

--- a/modules/theme/src/Schema/Setting/NumberSetting.php
+++ b/modules/theme/src/Schema/Setting/NumberSetting.php
@@ -31,6 +31,7 @@ class NumberSetting extends AbstractTextInputSetting
      * @param integer $min
      * @param integer $max
      * @param integer|float $step
+     * @param string $hint
      * @param integer|float|null $default
      * @param string|null $placeholder
      */
@@ -40,12 +41,14 @@ class NumberSetting extends AbstractTextInputSetting
         public readonly int $min,
         public readonly int $max,
         public readonly int|float $step = self::Step,
+        string $hint = '',
         mixed $default = null,
         ?string $placeholder = null,
     ) {
         parent::__construct(
             id: $id,
             label: $label,
+            hint: $hint,
             default: $default,
             placeholder: $placeholder,
         );
@@ -158,6 +161,7 @@ class NumberSetting extends AbstractTextInputSetting
             'min' => $this->min,
             'max' => $this->max,
             'step' => $this->step ?? 1,
+            'hint' => $this->hint,
             'default' => $this->default,
             'placeholder' => $this->placeholder,
         ];
@@ -172,6 +176,7 @@ class NumberSetting extends AbstractTextInputSetting
      *   min?: integer,
      *   max?: integer,
      *   step?: integer|float,
+     *   hint?: string,
      *   default?: integer|float,
      *   placeholder?: string,
      * } $data
@@ -184,6 +189,7 @@ class NumberSetting extends AbstractTextInputSetting
             min: $data['min'] ?? ArrayKeyMissingException::throw('min'),
             max: $data['max'] ?? ArrayKeyMissingException::throw('max'),
             step: $data['step'] ?? self::Step,
+            hint: $data['hint'] ?? '',
             default: $data['default'] ?? null,
             placeholder: $data['placeholder'] ?? null,
         );

--- a/modules/theme/src/Schema/Setting/SelectSetting.php
+++ b/modules/theme/src/Schema/Setting/SelectSetting.php
@@ -28,12 +28,14 @@ class SelectSetting extends AbstractInputSetting
      *
      * @param SchemaSettingId $id
      * @param string $label
+     * @param string $hint
      * @param string|null $default
      * @param SelectOption ...$options
      */
     public function __construct(
         SchemaSettingId $id,
         string $label,
+        string $hint = '',
         mixed $default = null,
         SelectOption ...$options,
     ) {
@@ -47,6 +49,7 @@ class SelectSetting extends AbstractInputSetting
         parent::__construct(
             id: $id,
             label: $label,
+            hint: $hint,
             default: $default,
         );
     }
@@ -71,6 +74,7 @@ class SelectSetting extends AbstractInputSetting
         return [
             'id' => $this->id->value(),
             'label' => $this->label,
+            'hint' => $this->hint,
             'default' => $this->default,
             'options' => array_map(
                 fn (SelectOption $option) => $option->toArray(),
@@ -89,6 +93,7 @@ class SelectSetting extends AbstractInputSetting
      *     value: string,
      *     label: string,
      *   }[],
+     *   hint?: string,
      *   default?: string,
      * } $data
      */
@@ -105,6 +110,7 @@ class SelectSetting extends AbstractInputSetting
         return new self(
             new SchemaSettingId($data['id'] ?? ArrayKeyMissingException::throw('id')),
             $data['label'] ?? ArrayKeyMissingException::throw('label'),
+            $data['hint'] ?? '',
             $data['default'] ?? null,
             ...array_map(
                 // If the option is a string, create a new SelectOption with the same value and label

--- a/modules/theme/src/Schema/Setting/TextSetting.php
+++ b/modules/theme/src/Schema/Setting/TextSetting.php
@@ -67,7 +67,6 @@ class TextSetting extends AbstractTextInputSetting
             'label' => $this->label,
             'default' => $this->default,
             'placeholder' => $this->placeholder,
-            'limit' => self::LimitLength,
         ];
     }
 

--- a/modules/theme/src/Schema/Setting/TextSetting.php
+++ b/modules/theme/src/Schema/Setting/TextSetting.php
@@ -65,6 +65,7 @@ class TextSetting extends AbstractTextInputSetting
         return [
             'id' => $this->id->value(),
             'label' => $this->label,
+            'hint' => $this->hint,
             'default' => $this->default,
             'placeholder' => $this->placeholder,
         ];
@@ -76,6 +77,7 @@ class TextSetting extends AbstractTextInputSetting
      * @param array{
      *   id?: string,
      *   label?: string,
+     *   hint?: string,
      *   default?: string,
      *   placeholder?: string,
      * } $data
@@ -85,6 +87,7 @@ class TextSetting extends AbstractTextInputSetting
         return new self(
             id: new SchemaSettingId($data['id'] ?? ArrayKeyMissingException::throw('id')),
             label: $data['label'] ?? ArrayKeyMissingException::throw('label'),
+            hint: $data['hint'] ?? '',
             default: $data['default'] ?? null,
             placeholder: $data['placeholder'] ?? null,
         );

--- a/modules/theme/src/Schema/Setting/TextareaSetting.php
+++ b/modules/theme/src/Schema/Setting/TextareaSetting.php
@@ -65,6 +65,7 @@ class TextareaSetting extends AbstractTextInputSetting
         return [
             'id' => $this->id->value(),
             'label' => $this->label,
+            'hint' => $this->hint,
             'default' => $this->default,
             'placeholder' => $this->placeholder,
         ];
@@ -76,6 +77,7 @@ class TextareaSetting extends AbstractTextInputSetting
      * @param array{
      *   id?: string,
      *   label?: string,
+     *   hint?: string,
      *   default?: string,
      *   placeholder?: string,
      * } $data
@@ -85,6 +87,7 @@ class TextareaSetting extends AbstractTextInputSetting
         return new self(
             id: new SchemaSettingId($data['id'] ?? ArrayKeyMissingException::throw('id')),
             label: $data['label'] ?? ArrayKeyMissingException::throw('label'),
+            hint: $data['hint'] ?? '',
             default: $data['default'] ?? null,
             placeholder: $data['placeholder'] ?? null,
         );

--- a/modules/theme/src/Schema/Setting/TextareaSetting.php
+++ b/modules/theme/src/Schema/Setting/TextareaSetting.php
@@ -67,7 +67,6 @@ class TextareaSetting extends AbstractTextInputSetting
             'label' => $this->label,
             'default' => $this->default,
             'placeholder' => $this->placeholder,
-            'limit' => self::LimitLength,
         ];
     }
 

--- a/resources/themes/simply/theme.json
+++ b/resources/themes/simply/theme.json
@@ -98,7 +98,8 @@
                     "id": "form",
                     "label": "Googleフォームなどの埋め込みタグ",
                     "default": "",
-                    "placeholder": "Googleフォームなどのiframe埋め込みタグの入力"
+                    "placeholder": "Googleフォームなどのiframe埋め込みタグの入力",
+                    "hint": "フォームの横幅を最大幅にするには、iframeタグにwidth=\"100%\"を追加してください。"
                 }
             ]
         }

--- a/resources/views/theme/sections/customization-form.twig
+++ b/resources/views/theme/sections/customization-form.twig
@@ -37,6 +37,7 @@
                             name: name,
                             label: setting.label,
                             value: value,
+                            hint: setting.hint,
                         }) }}
                     </div>
                 {% elseif setting.type == 'text' %}
@@ -46,6 +47,7 @@
                             name: name,
                             label: setting.label,
                             value: value,
+                            hint: setting.hint,
                             placeholder: setting.placeholder,
                         }) }}
                     </div>
@@ -59,6 +61,7 @@
                             max: setting.max,
                             step: setting.step,
                             value: value,
+                            hint: setting.hint,
                             placeholder: setting.placeholder,
                         }) }}
                     </div>
@@ -70,6 +73,7 @@
                             label: setting.label,
                             value: value,
                             options: setting.options,
+                            hint: setting.hint,
                         }) }}
                     </div>
                 {% elseif setting.type == 'checkbox' %}
@@ -79,6 +83,7 @@
                             name: name,
                             label: setting.label,
                             value: value,
+                            hint: setting.hint,
                         }) }}
                     </div>
                 {% elseif setting.type == 'textarea' %}
@@ -89,6 +94,7 @@
                             label: setting.label,
                             value: value,
                             rows: 5,
+                            hint: setting.hint,
                             placeholder: setting.placeholder,
                         }) }}
                     </div>
@@ -98,6 +104,7 @@
                             uid: setting.uid,
                             name: name,
                             label: setting.label,
+                            hint: setting.hint,
                             value: value,
                         }) }}
                     </div>


### PR DESCRIPTION
## 概要
テーマの入力スキーマ設定を配列化する際に、不使用のプロパティ``limit``を削除しました。
テーマカスタマイズの入力フォームにヒントを表示するためのプロパティを、入力スキーマ設定に追加しました。
