### PR TITLE
ブログ関連のアクションクラスをリファクタリング

### DIFF
--- a/src/CmsToolProvider.php
+++ b/src/CmsToolProvider.php
@@ -31,6 +31,11 @@ use Takemo101\CmsTool\Support\Webhook\WebhookHandlers;
 class CmsToolProvider implements Provider
 {
     /**
+     * @var string CmsTool Version number.
+     */
+    public const Version = '0.1.1';
+
+    /**
      * constructor
      *
      * @param LocalFilesystem $filesystem

--- a/src/Preset/MicroCms/Blog/BlogRoute.php
+++ b/src/Preset/MicroCms/Blog/BlogRoute.php
@@ -8,6 +8,7 @@ use Slim\Interfaces\RouteCollectorProxyInterface;
 use Takemo101\CmsTool\Preset\MicroCms\Shared\Action\ContentDetailAction;
 use Takemo101\CmsTool\Preset\MicroCms\Shared\Action\ContentIndexAction;
 use Takemo101\CmsTool\Preset\MicroCms\Shared\Action\TaxonomyIndexAction;
+use Takemo101\CmsTool\Preset\MicroCms\Shared\Action\TaxonomyIndexActionEndpoints;
 use Takemo101\CmsTool\Support\Shared\ImmutableArrayObject;
 
 class BlogRoute implements ThemeRoute
@@ -79,8 +80,10 @@ class BlogRoute implements ThemeRoute
         $proxy->get(
             "/{$ext->signatures->category}/{id}",
             new TaxonomyIndexAction(
-                taxonomyEndpoint: $ext->endpoints->category,
-                contentEndpoint: $ext->endpoints->blog,
+                endpoints: new TaxonomyIndexActionEndpoints(
+                    taxonomy: $ext->endpoints->category,
+                    content: $ext->endpoints->blog,
+                ),
                 relation: $ext->fields->category,
                 signature: $ext->signatures->category,
             ),
@@ -90,8 +93,10 @@ class BlogRoute implements ThemeRoute
         $proxy->get(
             "/{$ext->signatures->tag}/{id}",
             new TaxonomyIndexAction(
-                taxonomyEndpoint: $ext->endpoints->tag,
-                contentEndpoint: $ext->endpoints->blog,
+                endpoints: new TaxonomyIndexActionEndpoints(
+                    taxonomy: $ext->endpoints->tag,
+                    content: $ext->endpoints->blog,
+                ),
                 relation: $ext->fields->tag,
                 signature: $ext->signatures->tag,
                 multiple: true,

--- a/src/Preset/MicroCms/Shared/Action/ContentDetailAction.php
+++ b/src/Preset/MicroCms/Shared/Action/ContentDetailAction.php
@@ -26,7 +26,15 @@ class ContentDetailAction
         private readonly string $endpoint,
         private readonly string $signature,
     ) {
-        //
+        assert(
+            empty($endpoint) === false,
+            'The endpoint must not be empty',
+        );
+
+        assert(
+            empty($signature) === false,
+            'The signature must not be empty',
+        );
     }
 
     /**

--- a/src/Preset/MicroCms/Shared/Action/ContentIndexAction.php
+++ b/src/Preset/MicroCms/Shared/Action/ContentIndexAction.php
@@ -31,7 +31,20 @@ class ContentIndexAction extends AbstractIndexAction
         private readonly ?string $order = null,
         private readonly ?string $filter = null,
     ) {
-        //
+        assert(
+            empty($endpoint) === false,
+            'The endpoint must not be empty',
+        );
+
+        assert(
+            empty($signature) === false,
+            'The signature must not be empty',
+        );
+
+        assert(
+            $limit > 0,
+            'The limit must be greater than 0',
+        );
     }
 
     /**

--- a/src/Preset/MicroCms/Shared/Action/TaxonomyIndexAction.php
+++ b/src/Preset/MicroCms/Shared/Action/TaxonomyIndexAction.php
@@ -34,7 +34,27 @@ class TaxonomyIndexAction extends AbstractIndexAction
         private readonly ?string $order = null,
         private readonly bool $multiple = false,
     ) {
-        //
+        assert(
+            empty($relation) === false,
+            'The relation must not be empty',
+        );
+
+        assert(
+            empty($signature) === false,
+            'The signature must not be empty',
+        );
+
+        assert(
+            $limit > 0,
+            'The limit must be greater than 0',
+        );
+
+        if ($order) {
+            assert(
+                empty($order) === false,
+                'The order must not be empty',
+            );
+        }
     }
 
     /**

--- a/src/Preset/MicroCms/Shared/Action/TaxonomyIndexAction.php
+++ b/src/Preset/MicroCms/Shared/Action/TaxonomyIndexAction.php
@@ -19,8 +19,7 @@ class TaxonomyIndexAction extends AbstractIndexAction
     /**
      * constructor
      *
-     * @param string $taxonomyEndpoint
-     * @param string $contentEndpoint
+     * @param TaxonomyIndexActionEndpoints $endpoints
      * @param string $relation
      * @param string $signature
      * @param integer $limit
@@ -28,8 +27,7 @@ class TaxonomyIndexAction extends AbstractIndexAction
      * @param boolean $multiple
      */
     public function __construct(
-        private readonly string $taxonomyEndpoint,
-        private readonly string $contentEndpoint,
+        private readonly TaxonomyIndexActionEndpoints $endpoints,
         private readonly string $relation,
         private readonly string $signature,
         private readonly int $limit = 10,
@@ -56,7 +54,7 @@ class TaxonomyIndexAction extends AbstractIndexAction
         string $id,
     ): View {
         $taxonomy = $queryService->getOne(
-            endpoint: $this->taxonomyEndpoint,
+            endpoint: $this->endpoints->taxonomy,
             id: $id,
         );
 
@@ -72,7 +70,7 @@ class TaxonomyIndexAction extends AbstractIndexAction
         $operator = $this->multiple ? 'contains' : 'equals';
 
         $result = $queryService->getList(
-            endpoint: $this->contentEndpoint,
+            endpoint: $this->endpoints->content,
             pager: new Pager(
                 page: $this->getPage($params),
                 limit: $this->getLimit($params, $this->limit),

--- a/src/Preset/MicroCms/Shared/Action/TaxonomyIndexActionEndpoints.php
+++ b/src/Preset/MicroCms/Shared/Action/TaxonomyIndexActionEndpoints.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Takemo101\CmsTool\Preset\MicroCms\Shared\Action;
+
+readonly class TaxonomyIndexActionEndpoints
+{
+    /**
+     * constructor
+     *
+     * @param string $taxonomy
+     * @param string $content
+     */
+    public function __construct(
+        public string $taxonomy,
+        public string $content,
+    ) {
+        //
+    }
+}

--- a/src/Preset/MicroCms/Shared/Action/TaxonomyIndexActionEndpoints.php
+++ b/src/Preset/MicroCms/Shared/Action/TaxonomyIndexActionEndpoints.php
@@ -14,6 +14,14 @@ readonly class TaxonomyIndexActionEndpoints
         public string $taxonomy,
         public string $content,
     ) {
-        //
+        assert(
+            empty($taxonomy) === false,
+            'The taxonomy endpoint must not be empty',
+        );
+
+        assert(
+            empty($content) === false,
+            'The content endpoint must not be empty',
+        );
     }
 }


### PR DESCRIPTION
## 概要

ブログ関連の``TaxonomyIndexAction``や``ContentDetailAction``などのコンテンツページを表示するためのアクションクラスは、コンストラクタでmicroCMSのAPIに必要なオプション値を渡して``__invoke``メソッドでオプション値に従ってアクションを実行するような処理になっています。
ただ、オプション値に空白文字を渡しても実行されるようになってしまっていたので、アサーションによりオプション値の事前条件を表明するようにしました。

## 変更内容

1. ブログ関連のアクションクラスの修正
