### PR TITLE
CmsTool独自のフックタグの定義をリファクタ

### DIFF
--- a/resources/themes/simply/function.php
+++ b/resources/themes/simply/function.php
@@ -6,15 +6,16 @@ use Slim\Interfaces\RouteCollectorProxyInterface as Proxy;
 use Takemo101\CmsTool\HookTags;
 
 hook()->on(
-    HookTags::RegisterThemeRoute,
-    function (
-        Proxy $proxy,
-    ) {
-        $proxy->get(
+    // ActiveThemeRouteRegistered は、選択中テーマのルートが登録された後に呼ばれるフックです。
+    // 選択中テーマに設定しているプリセットに応じたルートが事前に登録されます。
+    // テーマ独自のルートを登録するためには、このフック処理を使ってください。
+    HookTags::ActiveThemeRouteRegistered,
+    fn (Proxy $proxy) => $proxy
+        // この例では、``/sample`` というパスにGETリクエストがあった場合に、404ページを表示するルートを登録しています。
+        ->get(
             '/sample',
             fn (
                 ServerRequestInterface $request,
             ) => throw new HttpNotFoundException($request),
-        );
-    },
+        ),
 );

--- a/src/HookTags.php
+++ b/src/HookTags.php
@@ -6,7 +6,7 @@ class HookTags
 {
     /**
      * A hook tag called when registering an active theme route.
-     * The Hook method takes the `` RoutecollectorProxyInterface`` as an argument.
+     * The Hook method takes the `` RouteCollectorProxyInterface`` as an argument.
      */
     public const RegisterThemeRoute = 'register_theme_route';
 

--- a/src/HookTags.php
+++ b/src/HookTags.php
@@ -8,17 +8,17 @@ class HookTags
      * A hook tag called when registering an active theme route.
      * The Hook method takes the `` RouteCollectorProxyInterface`` as an argument.
      */
-    public const RegisterThemeRoute = 'register_theme_route';
+    public const ActiveThemeRouteRegistered = 'cmstool.active_theme_route_registered';
 
     /**
      * Hook tag called when loading the active theme
      * The Hook method takes the ``ActiveTheme`` as an argument.
      */
-    public const LoadedActiveTheme = 'loaded_active_theme';
+    public const ActiveThemeLoaded = 'cmstool.active_theme_loaded';
 
     /**
      * Hook tag called when the administrator session is started.
      * The Hook method takes the ``AdminSession`` as an argument.
      */
-    public const AdminSessionStarted = 'admin_session_started';
+    public const AdminSessionStarted = 'cmstool.admin_session_started';
 };

--- a/src/Support/Theme/ActiveThemeFunctionLoader.php
+++ b/src/Support/Theme/ActiveThemeFunctionLoader.php
@@ -71,7 +71,7 @@ class ActiveThemeFunctionLoader
         }
 
         $this->hook->doTyped($activeTheme);
-        $this->hook->do(HookTags::LoadedActiveTheme, $activeTheme);
+        $this->hook->do(HookTags::ActiveThemeLoaded, $activeTheme);
     }
 
     /**

--- a/src/Support/Theme/ActiveThemeRouteRegister.php
+++ b/src/Support/Theme/ActiveThemeRouteRegister.php
@@ -49,6 +49,6 @@ class ActiveThemeRouteRegister
         }
 
         // Register the route of the theme
-        $this->hook->do(HookTags::RegisterThemeRoute, $proxy);
+        $this->hook->do(HookTags::ActiveThemeRouteRegistered, $proxy);
     }
 }


### PR DESCRIPTION
## 概要

CmsTool独自の既存フックタグの定数名などが処理を表していない名前だったので、定数名とその値をリファクタしました。
リファクタに伴い``simply``テーマの``function.php``のexampleフック処理に丁寧なコメントを追記しました。

