### PR TITLE
PHPのビルトインサーバーを起動したかどうかの判定を``config/app.php``に設定

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -24,5 +24,8 @@ return [
     'locale' => 'ja',
 
     // Built-in server flag
-    'built_in_server' => (bool) env(ServeCommand::BuiltInServerEnvironment, false),
+    'built_in_server' => (bool) env(
+        ServeCommand::BuiltInServerEnvironment,
+        php_sapi_name() === 'cli-server', // 環境変数BUILT_IN_SERVERが設定されていなければ、built-in serverが動いているかどうかを判定
+    ),
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -26,6 +26,6 @@ return [
     // Built-in server flag
     'built_in_server' => (bool) env(
         ServeCommand::BuiltInServerEnvironment,
-        php_sapi_name() === 'cli-server', // 環境変数BUILT_IN_SERVERが設定されていなければ、built-in serverが動いているかどうかを判定
+        php_sapi_name() === 'cli-server', // 「BUILT_IN_SERVER」環境変数が設定されていなければ、built-in serverが稼働しているかどうかを判定する
     ),
 ];


### PR DESCRIPTION
## 概要
ビルトインサーバーでの動作かどうかを設定する``app.built_in_server``config値に、一般的なPHPのビルトインサーバーを起動した場合の判定処理を設定する。
