### PR TITLE
テーマファイルのパスを直接指定してテーマを探せるように修正

### DIFF
--- a/config/vendor/theme.php
+++ b/config/vendor/theme.php
@@ -11,6 +11,11 @@ return [
         base_path('themes'),
     ],
 
+    // Directory paths for each theme
+    'paths' => [
+        // Specify the path to the directory of the theme that contains theme.json
+    ],
+
     // Directory to place themes when copying
     'copy' => base_path('themes'),
 

--- a/modules/theme/config/theme.php
+++ b/modules/theme/config/theme.php
@@ -7,6 +7,11 @@ return [
         base_path('themes'),
     ],
 
+    // Directory paths for each theme
+    'paths' => [
+        // Specify the path to the directory of the theme that contains theme.json
+    ],
+
     // Directory to place themes when copying
     'copy' => base_path('themes'),
 

--- a/modules/theme/src/Contract/ThemeFinder.php
+++ b/modules/theme/src/Contract/ThemeFinder.php
@@ -38,4 +38,12 @@ interface ThemeFinder
      * @return void
      */
     public function addLocation(string $location): void;
+
+    /**
+     * Add a path to the finder.
+     *
+     * @param string $path Theme directory path
+     * @return void
+     */
+    public function addPath(string $path): void;
 }

--- a/modules/theme/src/Contract/ThemeFinder.php
+++ b/modules/theme/src/Contract/ThemeFinder.php
@@ -42,7 +42,7 @@ interface ThemeFinder
     /**
      * Add a path to the finder.
      *
-     * @param string $path Theme directory path
+     * @param string $path The directory path where theme.json is located.
      * @return void
      */
     public function addPath(string $path): void;

--- a/modules/theme/src/DefaultThemeFinder.php
+++ b/modules/theme/src/DefaultThemeFinder.php
@@ -160,6 +160,8 @@ class DefaultThemeFinder implements ThemeFinder
                 return $path;
             }
         }
+
+        return null;
     }
 
     /**

--- a/modules/theme/tests/Theme/DefaultThemeFinderTest.php
+++ b/modules/theme/tests/Theme/DefaultThemeFinderTest.php
@@ -114,5 +114,24 @@ describe(
             // Expect the locations array to contain the new location
             expect($finder->getLocations())->toContain($location);
         });
+
+        it('adds a new path', function () {
+            $filesystem = m::mock(LocalFilesystem::class);
+            $helper = new PathHelper();
+            $finder = new DefaultThemeFinder($filesystem, $helper);
+
+            $path = '/new/path/to/themes';
+
+            // Mock the filesystem's realpath method to return the path
+            $filesystem->shouldReceive('realpath')
+                ->with($path)
+                ->andReturn($path);
+
+            // Call the addPath method
+            $finder->addPath($path);
+
+            // Expect the paths array to contain the new path
+            expect($finder->getPaths())->toContain($path);
+        });
     },
 )->group('DefaultThemeFinder', 'theme');


### PR DESCRIPTION
## 概要

テーマを探す処理では、各テーマファイルを配置するディレクトリを指定するようにしていますが、テーマファイル自体のパスを指定してテーマを探せるように修正しました。
このことにより、テーマの配置先の制御をやりやすくなります。

## 変更内容

1. ``ThemeFinder``インタフェースの定義にテーマパスの追加メソッドを追加
2. ``DefaultThemeFinder``にインタフェースに追加した定義の処理追加
3. ``config/theme.php``にテーマパスを設定できるよう変更

