### PR TITLE
``theme.json``を保存する場合のエスケープ処理を無効化

### DIFF
--- a/modules/theme/src/DefaultThemeAccessor.php
+++ b/modules/theme/src/DefaultThemeAccessor.php
@@ -43,9 +43,10 @@ class DefaultThemeAccessor implements ThemeAccessor
         $path = $this->helper->getThemeSettingPath($theme);
 
         try {
+            // Since theme.json may be manually edited, prioritize readability and do not escape Unicode and slashes.
             $json = json_encode(
                 $theme->meta->toArray(),
-                JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT,
+                JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT,
             );
         } catch (\JsonException $e) {
             throw ThemeSaveException::encodeError($path, $e);


### PR DESCRIPTION
## 概要

``theme.json``を管理画面から編集する場合、保存したjsonコードの中身がエスケープ処理されて非常に読みにくいので、``theme.json``は手動で編集することも想定されることもあり、エスケープ処理を無効にしました。

ただし、エスケープを無効にすることで、手動での編集に注意を払ってもらう必要がある。
