### PR TITLE
モジュールのインタフェースへの依存設定を``config``ファイルの``dependencies``に設定するように修正

### DIFF
--- a/config/vendor/support.php
+++ b/config/vendor/support.php
@@ -18,10 +18,6 @@ return [
         'cost' => 10,
     ],
 
-    'json' => [
-        //
-    ],
-
     'translation' => [
 
         // Settings for translation by file

--- a/modules/cache/config/cache.php
+++ b/modules/cache/config/cache.php
@@ -1,15 +1,10 @@
 <?php
 
-use CmsTool\Cache\FilesystemCacheItemPoolFactory;
-
 return [
 
     // Whether to enable cache
     // This setting is reflected when using ControlledCache
     'enabled' => (bool) env('CACHE_ENABLED', true),
-
-    // CacheItemPoolFactory implementation class name
-    'factory' => FilesystemCacheItemPoolFactory::class,
 
     // Default lifetime seconds
     'lifetime' => 21600, // 6 hours
@@ -26,5 +21,10 @@ return [
 
         // Cache database file path
         'path' => storage_path('cache/data/sqlite'),
+    ],
+
+    // This configuration is used to modify the dependencies for cache.
+    'dependencies' => [
+        // CmsTool\Cache\Contract\CacheItemPoolFactory::class => CmsTool\Cache\FilesystemCacheItemPoolFactory::class,
     ],
 ];

--- a/modules/cache/src/CacheProvider.php
+++ b/modules/cache/src/CacheProvider.php
@@ -31,11 +31,13 @@ class CacheProvider implements Provider
     public function register(Definitions $definitions): void
     {
         $definitions->add([
-            CacheItemPoolFactory::class => new ConfigBasedDefinitionReplacer(
-                FilesystemCacheItemPoolFactory::class,
-                'cache.factory',
-            ),
             CacheItemPoolInterface::class => fn (CacheItemPoolFactory $factory) => $factory->create(),
+            ...ConfigBasedDefinitionReplacer::createDependencyDefinitions(
+                dependencies: [
+                    CacheItemPoolFactory::class => FilesystemCacheItemPoolFactory::class,
+                ],
+                configKeyPrefix: 'cache',
+            )
         ]);
     }
 

--- a/modules/session/config/session.php
+++ b/modules/session/config/session.php
@@ -26,6 +26,7 @@ return [
         'persistent_token_mode' => true,
     ],
 
+    // This configuration is used to modify the dependencies for session.
     'dependencies' => [
         // CmsTool\Session\Contract\SessionFactory::class => CmsTool\Session\NativePhpSessionFactory::class,
     ],

--- a/modules/session/config/session.php
+++ b/modules/session/config/session.php
@@ -1,10 +1,6 @@
 <?php
 
-use CmsTool\Session\NativePhpSessionFactory;
-
 return [
-    // SessionFactory implementation class name
-    'factory' => NativePhpSessionFactory::class,
 
     // FlashSession classes
     'flashes' => [
@@ -28,5 +24,9 @@ return [
         'strength' => 16,
 
         'persistent_token_mode' => true,
-    ]
+    ],
+
+    'dependencies' => [
+        // CmsTool\Session\Contract\SessionFactory::class => CmsTool\Session\NativePhpSessionFactory::class,
+    ],
 ];

--- a/modules/session/src/SessionProvider.php
+++ b/modules/session/src/SessionProvider.php
@@ -34,10 +34,6 @@ class SessionProvider implements Provider
     {
         $definitions->add([
             'csrf' => get(CsrfGuard::class),
-            SessionFactory::class => new ConfigBasedDefinitionReplacer(
-                NativePhpSessionFactory::class,
-                'session.factory',
-            ),
             FlashSessionsFactory::class => function (
                 ConfigRepository $config,
                 Hook $hook,
@@ -51,6 +47,12 @@ class SessionProvider implements Provider
 
                 return $factory;
             },
+            ...ConfigBasedDefinitionReplacer::createDependencyDefinitions(
+                dependencies: [
+                    SessionFactory::class => NativePhpSessionFactory::class,
+                ],
+                configKeyPrefix: 'session',
+            ),
         ]);
     }
 

--- a/modules/support/config/support.php
+++ b/modules/support/config/support.php
@@ -1,17 +1,9 @@
 <?php
 
-use CmsTool\Support\Encrypt\DefaultEncrypter;
 use CmsTool\Support\Encrypt\EncryptCipher;
-use CmsTool\Support\Hash\BcryptHasher;
-use CmsTool\Support\JsonAccess\DefaultJsonAccessor;
-use CmsTool\Support\Translation\DefaultTranslator;
-use CmsTool\Support\Translation\TranslationJsonFileAccessor;
 
 return [
     'encrypt' => [
-
-        // Default encrypter class
-        'encrypter' => DefaultEncrypter::class,
 
         // Encryption cipher
         'cipher' => EncryptCipher::AES_128_CBC,
@@ -22,26 +14,11 @@ return [
 
     'hash' => [
 
-        // Default hasher class
-        'hasher' => BcryptHasher::class,
-
         // Default hash cost
         'cost' => 10,
     ],
 
-    'json' => [
-
-        // Default JsonArrayAccessor class
-        'accessor' => DefaultJsonAccessor::class,
-    ],
-
     'translation' => [
-
-        // Default Translator class
-        'translator' => DefaultTranslator::class,
-
-        // Default TranslationAccessor class
-        'accessor' => TranslationJsonFileAccessor::class,
 
         // Settings for translation by file
         'file' => [
@@ -73,6 +50,11 @@ return [
 
     // This configuration is used to modify the dependencies for the support module
     'dependencies' => [
-        // \CmsTool\Support\AccessLog\AccessLoggerFactory::class => CmsTool\Support\AccessLog\FileAccessLoggerFactory::class,
+        // CmsTool\Support\Encrypt\Encrypter::class => CmsTool\Support\Encrypt\DefaultEncrypter::class,
+        // CmsTool\Support\Hash\Hasher::class => CmsTool\Support\Hash\BcryptHasher::class,
+        // CmsTool\Support\JsonAccess\JsonArrayAccessor::class => CmsTool\Support\JsonAccess\DefaultJsonAccessor::class,
+        // CmsTool\Support\Translation\TranslationAccessor::class => CmsTool\Support\Translation\TranslationJsonFileAccessor::class,
+        // CmsTool\Support\Translation\Translator::class => CmsTool\Support\Translation\DefaultTranslator::class,
+        // CmsTool\Support\AccessLog\AccessLoggerFactory::class => CmsTool\Support\AccessLog\FileAccessLoggerFactory::class,
     ],
 ];

--- a/modules/support/src/SupportProvider.php
+++ b/modules/support/src/SupportProvider.php
@@ -64,7 +64,6 @@ class SupportProvider implements Provider
     {
         $this->registerJsonAccess($definitions);
         $this->registerEncrypt($definitions);
-        $this->registerHash($definitions);
         $this->registerValidation($definitions);
         $this->registerTranslation($definitions);
         $this->registerAccessLog($definitions);
@@ -72,6 +71,11 @@ class SupportProvider implements Provider
         $definitions->add([
             ...ConfigBasedDefinitionReplacer::createDependencyDefinitions(
                 dependencies: [
+                    Encrypter::class => DefaultEncrypter::class,
+                    Hasher::class => BcryptHasher::class,
+                    JsonArrayAccessor::class => DefaultJsonAccessor::class,
+                    TranslationAccessor::class => TranslationJsonFileAccessor::class,
+                    Translator::class => DefaultTranslator::class,
                     AccessLoggerFactory::class => FileAccessLoggerFactory::class,
                 ],
                 configKeyPrefix: 'support',
@@ -124,10 +128,6 @@ class SupportProvider implements Provider
     public function registerJsonAccess(Definitions $definitions): void
     {
         $definitions->add([
-            JsonArrayAccessor::class => new ConfigBasedDefinitionReplacer(
-                DefaultJsonAccessor::class,
-                'support.json.accessor',
-            ),
             JsonArrayLoader::class => get(JsonArrayAccessor::class),
             JsonArraySaver::class => get(JsonArrayAccessor::class),
         ]);
@@ -164,26 +164,6 @@ class SupportProvider implements Provider
                     $cipher,
                 );
             },
-            Encrypter::class => new ConfigBasedDefinitionReplacer(
-                DefaultEncrypter::class,
-                'support.encrypt.encrypter',
-            ),
-        ]);
-    }
-
-    /**
-     * Execute Hash providing process.
-     *
-     * @param Definitions $definitions
-     * @return void
-     */
-    public function registerHash(Definitions $definitions): void
-    {
-        $definitions->add([
-            Hasher::class => new ConfigBasedDefinitionReplacer(
-                BcryptHasher::class,
-                'support.hash.hasher',
-            ),
         ]);
     }
 
@@ -214,18 +194,8 @@ class SupportProvider implements Provider
     {
         $definitions->add([
             TranslatorInterface::class => get(SymfonyTranslationProxy::class),
-            TranslationAccessor::class => new ConfigBasedDefinitionReplacer(
-                TranslationJsonFileAccessor::class,
-                'support.translation.accessor',
-                true,
-            ),
             TranslationLoader::class => get(TranslationAccessor::class),
             TranslationSaver::class => get(TranslationAccessor::class),
-            Translator::class => new ConfigBasedDefinitionReplacer(
-                DefaultTranslator::class,
-                'support.translation.translator',
-                true,
-            ),
         ]);
     }
 

--- a/modules/view/config/view.php
+++ b/modules/view/config/view.php
@@ -1,7 +1,6 @@
 <?php
 
 use CmsTool\View\Contract\Htmlable;
-use CmsTool\View\DefaultTemplateFinder;
 use CmsTool\View\Twig\Extension\ComponentExtension;
 use CmsTool\View\Twig\Extension\ConfigExtension;
 use CmsTool\View\Twig\Extension\RequestExtension;
@@ -9,18 +8,11 @@ use CmsTool\View\Twig\Extension\FiltersExtension;
 use CmsTool\View\Twig\Extension\FormExtension;
 use CmsTool\View\Twig\Extension\FunctionsExtension;
 use CmsTool\View\Twig\Extension\RouteExtension;
-use CmsTool\View\Twig\TwigTemplateRenderer;
 use CmsTool\View\View;
 use Takemo101\Chubby\Contract\Renderable;
 use Twig\Extension\StringLoaderExtension;
 
 return [
-
-    // TemplateFinder implementation class name
-    'finder' => DefaultTemplateFinder::class,
-
-    // TemplateRenderer implementation class name
-    'renderer' => TwigTemplateRenderer::class,
 
     'locations' => [
         base_path('resources/views'),
@@ -117,5 +109,11 @@ return [
     // Set up components
     'components' => [
         // 'name' => class-string<object&callable>,
+    ],
+
+    // This configuration is used to modify the dependencies for the view.
+    'dependencies' => [
+        // CmsTool\View\Contract\TemplateFinder::class => CmsTool\View\DefaultTemplateFinder::class,
+        // CmsTool\View\Contract\TemplateRenderer::class => CmsTool\View\Twig\TwigTemplateRenderer::class,
     ],
 ];

--- a/modules/view/config/view.php
+++ b/modules/view/config/view.php
@@ -111,7 +111,7 @@ return [
         // 'name' => class-string<object&callable>,
     ],
 
-    // This configuration is used to modify the dependencies for the view.
+    // This configuration is used to modify the dependencies for view.
     'dependencies' => [
         // CmsTool\View\Contract\TemplateFinder::class => CmsTool\View\DefaultTemplateFinder::class,
         // CmsTool\View\Contract\TemplateRenderer::class => CmsTool\View\Twig\TwigTemplateRenderer::class,

--- a/modules/view/src/ViewProvider.php
+++ b/modules/view/src/ViewProvider.php
@@ -54,15 +54,6 @@ class ViewProvider implements Provider
     public function register(Definitions $definitions): void
     {
         $definitions->add([
-            TemplateFinder::class => new ConfigBasedDefinitionReplacer(
-                DefaultTemplateFinder::class,
-                'view.finder',
-                true,
-            ),
-            TemplateRenderer::class => new ConfigBasedDefinitionReplacer(
-                TwigTemplateRenderer::class,
-                'view.renderer',
-            ),
             DataAccessors::class => function (
                 DataAccessorsFactory $factory,
                 Hook $hook,
@@ -159,6 +150,13 @@ class ViewProvider implements Provider
 
                 return $filters;
             },
+            ...ConfigBasedDefinitionReplacer::createDependencyDefinitions(
+                dependencies: [
+                    TemplateFinder::class => DefaultTemplateFinder::class,
+                    TemplateRenderer::class => TwigTemplateRenderer::class,
+                ],
+                configKeyPrefix: 'view',
+            )
         ]);
     }
 


### PR DESCRIPTION
## 概要

以前から、各機能のインタフェースへの依存関係を``config``ファイルの``dependencies``に配列で設定できる機能があったのですが、モジュールが対応していなかったので今回対応しました。
