### PR TITLE
読み取り専用テーマのカスタマイズデータの格納先修正

### DIFF
--- a/modules/theme/src/Schema/DefaultThemeCustomizationAccessor.php
+++ b/modules/theme/src/Schema/DefaultThemeCustomizationAccessor.php
@@ -39,7 +39,12 @@ class DefaultThemeCustomizationAccessor implements ThemeCustomizationAccessor
     {
         $path = $this->helper->getCustomizationDataPath($theme);
 
-        $this->makeReadonlyThemeDirectory($theme);
+        // If the theme is read-only, there is a possibility that the path to the temporary directory does not exist,
+        // so we need to add a process to create the directory before the save operation.
+        $this->helper->makeTemporaryDirectoryOrSkip(
+            theme: $theme,
+            filesystem: $this->filesystem,
+        );
 
         try {
             $json = json_encode(
@@ -94,22 +99,5 @@ class DefaultThemeCustomizationAccessor implements ThemeCustomizationAccessor
         }
 
         return $theme->refineCustomizationWithDefaults($data);
-    }
-
-    /**
-     * Make a temporary directory if the theme is readonly.
-     *
-     * @param Theme $theme
-     * @return void
-     */
-    private function makeReadonlyThemeDirectory(Theme $theme): void
-    {
-        if ($theme->isReadonly()) {
-            $directory = $this->helper->getTemporaryPath($theme);
-
-            if (!$this->filesystem->exists($directory)) {
-                $this->filesystem->makeDirectory($directory);
-            }
-        }
     }
 }

--- a/modules/theme/src/Schema/DefaultThemeCustomizationAccessor.php
+++ b/modules/theme/src/Schema/DefaultThemeCustomizationAccessor.php
@@ -39,6 +39,8 @@ class DefaultThemeCustomizationAccessor implements ThemeCustomizationAccessor
     {
         $path = $this->helper->getCustomizationDataPath($theme);
 
+        $this->makeReadonlyThemeDirectory($theme);
+
         try {
             $json = json_encode(
                 $theme->refineCustomizationWithDefaults($data),
@@ -92,5 +94,22 @@ class DefaultThemeCustomizationAccessor implements ThemeCustomizationAccessor
         }
 
         return $theme->refineCustomizationWithDefaults($data);
+    }
+
+    /**
+     * Make a temporary directory if the theme is readonly.
+     *
+     * @param Theme $theme
+     * @return void
+     */
+    private function makeReadonlyThemeDirectory(Theme $theme): void
+    {
+        if ($theme->isReadonly()) {
+            $directory = $this->helper->getTemporaryPath($theme);
+
+            if (!$this->filesystem->exists($directory)) {
+                $this->filesystem->makeDirectory($directory);
+            }
+        }
     }
 }

--- a/modules/theme/src/ThemePathHelper.php
+++ b/modules/theme/src/ThemePathHelper.php
@@ -4,7 +4,11 @@ namespace CmsTool\Theme;
 
 use DI\Attribute\Inject;
 use Takemo101\Chubby\Filesystem\PathHelper;
+use BadMethodCallException;
 
+/**
+ * @mixin PathHelper
+ */
 class ThemePathHelper
 {
     /**
@@ -78,8 +82,8 @@ class ThemePathHelper
     {
         return $theme->isReadonly()
             ? $this->getTemporaryPath(
-                'customization',
-                "{$theme->id}-data.json",
+                $theme,
+                ThemeConfig::CustomizationDataFilename,
             )
             : $this->getThemePath(
                 $theme,
@@ -122,13 +126,15 @@ class ThemePathHelper
     /**
      * Get temporary path
      *
+     * @param Theme $theme
      * @param string ...$paths
      * @return string
      */
-    public function getTemporaryPath(string ...$paths): string
+    public function getTemporaryPath(Theme $theme, string ...$paths): string
     {
         return $this->helper->join(
             $this->temporaryDirectory,
+            $theme->id->value(),
             ...$paths,
         );
     }
@@ -153,5 +159,22 @@ class ThemePathHelper
     public function extractThemeId(string $path): ThemeId
     {
         return new ThemeId($this->helper->basename($path));
+    }
+
+    /**
+     * Call helper method
+     *
+     * @param string $name
+     * @param mixed[] $arguments
+     * @return mixed
+     * @throws BadMethodCallException
+     */
+    public function __call(string $name, array $arguments): mixed
+    {
+        if (method_exists($this->helper, $name)) {
+            return $this->helper->{$name}(...$arguments);
+        }
+
+        throw new BadMethodCallException("Method {$name} does not exist");
     }
 }

--- a/modules/theme/src/ThemePathHelper.php
+++ b/modules/theme/src/ThemePathHelper.php
@@ -5,6 +5,7 @@ namespace CmsTool\Theme;
 use DI\Attribute\Inject;
 use Takemo101\Chubby\Filesystem\PathHelper;
 use BadMethodCallException;
+use Takemo101\Chubby\Filesystem\LocalFilesystem;
 
 /**
  * @mixin PathHelper
@@ -124,7 +125,8 @@ class ThemePathHelper
     }
 
     /**
-     * Get temporary path
+     * Get the directory for temporarily storing files such as customization data and assets for read-only themes.
+     * The data for read-only themes will be saved in this directory.
      *
      * @param Theme $theme
      * @param string ...$paths
@@ -159,6 +161,25 @@ class ThemePathHelper
     public function extractThemeId(string $path): ThemeId
     {
         return new ThemeId($this->helper->basename($path));
+    }
+
+    /**
+     * Make a temporary directory if the theme is readonly.
+     * If the directory already exists, it will be skipped.
+     *
+     * @param Theme $theme
+     * @param LocalFilesystem $filesystem
+     * @return void
+     */
+    public function makeTemporaryDirectoryOrSkip(Theme $theme, LocalFilesystem $filesystem): void
+    {
+        if ($theme->isReadonly()) {
+            $directory = $this->getTemporaryPath($theme);
+
+            if (!$filesystem->exists($directory)) {
+                $filesystem->makeDirectory($directory);
+            }
+        }
     }
 
     /**

--- a/modules/theme/tests/Schema/DefaultThemeCustomizationAccessorTest.php
+++ b/modules/theme/tests/Schema/DefaultThemeCustomizationAccessorTest.php
@@ -27,6 +27,11 @@ describe(
                 ->with($theme)
                 ->andReturn('/path/to/customization.json');
 
+            $this->helper->shouldReceive('makeTemporaryDirectoryOrSkip')
+                ->once()
+                ->with($theme, $this->filesystem)
+                ->andReturnNull();
+
             $this->filesystem->shouldReceive('write')
                 ->once()
                 ->with('/path/to/customization.json', $json)
@@ -36,10 +41,6 @@ describe(
                 ->once()
                 ->with($data)
                 ->andReturn($data);
-
-            $theme->shouldReceive('isReadonly')
-                ->once()
-                ->andReturn(false);
 
             $this->accessor->save($theme, $data);
         });
@@ -53,6 +54,11 @@ describe(
                 ->with($theme)
                 ->andReturn('/path/to/customization.json');
 
+            $this->helper->shouldReceive('makeTemporaryDirectoryOrSkip')
+                ->once()
+                ->with($theme, $this->filesystem)
+                ->andReturnNull();
+
             $this->filesystem->shouldReceive('write')
                 ->never();
 
@@ -60,10 +66,6 @@ describe(
                 ->once()
                 ->with($data)
                 ->andReturn($data);
-
-            $theme->shouldReceive('isReadonly')
-                ->once()
-                ->andReturn(false);
 
             expect(
                 fn () =>
@@ -81,6 +83,11 @@ describe(
                 ->with($theme)
                 ->andReturn('/path/to/customization.json');
 
+            $this->helper->shouldReceive('makeTemporaryDirectoryOrSkip')
+                ->once()
+                ->with($theme, $this->filesystem)
+                ->andReturnNull();
+
             $this->filesystem->shouldReceive('write')
                 ->once()
                 ->with('/path/to/customization.json', $json)
@@ -90,10 +97,6 @@ describe(
                 ->once()
                 ->with($data)
                 ->andReturn($data);
-
-            $theme->shouldReceive('isReadonly')
-                ->once()
-                ->andReturn(false);
 
             expect(
                 fn () =>
@@ -177,52 +180,6 @@ describe(
             expect(function () use ($theme) {
                 $this->accessor->load($theme);
             })->toThrow(ThemeLoadException::class);
-        });
-
-        it('should save the customization data to a temporary directory if the theme is readonly', function () {
-            $theme = m::mock(Theme::class);
-            $data = ['color' => 'blue'];
-            $json = json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
-
-            $dataPath = '/path/to/customization.json';
-
-            $directoryPath = '/path/to';
-
-            $this->helper->shouldReceive('getCustomizationDataPath')
-                ->once()
-                ->with($theme)
-                ->andReturn($dataPath);
-
-            $this->helper->shouldReceive('getTemporaryPath')
-                ->once()
-                ->with($theme)
-                ->andReturn($directoryPath);
-
-            $this->filesystem->shouldReceive('exists')
-                ->once()
-                ->with($directoryPath)
-                ->andReturn(false);
-
-            $this->filesystem->shouldReceive('makeDirectory')
-                ->once()
-                ->with($directoryPath)
-                ->andReturn(true);
-
-            $this->filesystem->shouldReceive('write')
-                ->once()
-                ->with($dataPath, $json)
-                ->andReturn(true);
-
-            $theme->shouldReceive('refineCustomizationWithDefaults')
-                ->once()
-                ->with($data)
-                ->andReturn($data);
-
-            $theme->shouldReceive('isReadonly')
-                ->once()
-                ->andReturn(true);
-
-            $this->accessor->save($theme, $data);
         });
     }
 )->group('DefaultThemeCustomizationAccessor', 'schema');

--- a/modules/theme/tests/Theme/ThemePathHelperTest.php
+++ b/modules/theme/tests/Theme/ThemePathHelperTest.php
@@ -71,5 +71,15 @@ describe(
 
             expect($actual)->toBe($expected);
         })->skipOnWindows();
+
+        it('should call PathHelper method', function (string $method) {
+            $actual = $this->helper->{$method}('/path/to/file.txt');
+
+            expect($actual)->not->toBeEmpty();
+        })->with([
+            'dirname',
+            'basename',
+            'extension',
+        ]);
     }
 )->group('ThemePathHelper', 'theme');


### PR DESCRIPTION
## 概要
今後テーマのカスタマイズデータとして画像などのファイルを扱うことを考えると、ファイルと``data.json``を同じディレクトリに保存した方が管理しやすいので、テーマIDが名前となるディレクトリを作成して、そこに``data.json``を保存するように修正しました。
