### PR TITLE
テキスト入力スキーマ設定に入力フォーマットを追加した

### DIFF
--- a/modules/theme/src/Schema/Setting/TextInputFormat.php
+++ b/modules/theme/src/Schema/Setting/TextInputFormat.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace CmsTool\Theme\Schema\Setting;
+
+/**
+ * Format types for text input forms.
+ */
+enum TextInputFormat: string
+{
+    case Text = 'text';
+    case Email = 'email';
+    case Url = 'url';
+
+    /**
+     * Default value when no format is specified in the schema settings.
+     *
+     * @return self
+     */
+    public static function default(): self
+    {
+        return self::Text;
+    }
+}

--- a/modules/theme/src/Schema/Setting/TextSetting.php
+++ b/modules/theme/src/Schema/Setting/TextSetting.php
@@ -24,6 +24,33 @@ class TextSetting extends AbstractTextInputSetting
     public const LimitLength = 500;
 
     /**
+     * constructor
+     *
+     * @param SchemaSettingId $id
+     * @param string $label
+     * @param TextInputFormat $format
+     * @param string $hint
+     * @param string|null $default
+     * @param string|null $placeholder
+     */
+    public function __construct(
+        SchemaSettingId $id,
+        string $label,
+        public readonly TextInputFormat $format = TextInputFormat::Text,
+        string $hint = '',
+        mixed $default = null,
+        ?string $placeholder = null,
+    ) {
+        parent::__construct(
+            id: $id,
+            label: $label,
+            hint: $hint,
+            default: $default,
+            placeholder: $placeholder,
+        );
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @return string
@@ -65,6 +92,7 @@ class TextSetting extends AbstractTextInputSetting
         return [
             'id' => $this->id->value(),
             'label' => $this->label,
+            'format' => $this->format->value,
             'hint' => $this->hint,
             'default' => $this->default,
             'placeholder' => $this->placeholder,
@@ -77,6 +105,7 @@ class TextSetting extends AbstractTextInputSetting
      * @param array{
      *   id?: string,
      *   label?: string,
+     *   format?: string,
      *   hint?: string,
      *   default?: string,
      *   placeholder?: string,
@@ -87,6 +116,10 @@ class TextSetting extends AbstractTextInputSetting
         return new self(
             id: new SchemaSettingId($data['id'] ?? ArrayKeyMissingException::throw('id')),
             label: $data['label'] ?? ArrayKeyMissingException::throw('label'),
+            // If no format is specified or an invalid value is specified, use the default value.
+            format: TextInputFormat::tryFrom(
+                $data['format'] ?? TextInputFormat::default()->value,
+            ) ?? TextInputFormat::default(),
             hint: $data['hint'] ?? '',
             default: $data['default'] ?? null,
             placeholder: $data['placeholder'] ?? null,

--- a/resources/themes/simply/theme.json
+++ b/resources/themes/simply/theme.json
@@ -187,6 +187,7 @@
                     "type": "text",
                     "id": "profile_avatar",
                     "label": "プロフィール画像",
+                    "format": "url",
                     "placeholder": "https:// から始まるプロフィール画像のURLの入力",
                     "hint": "プロフィール画像はmicroCMSなどにアップロードしてURLを入力してください。"
                 },
@@ -194,36 +195,42 @@
                     "type": "text",
                     "id": "profile_link",
                     "label": "SNS以外のリンク",
+                    "format": "url",
                     "placeholder": "https:// から始まるURLの入力"
                 },
                 {
                     "type": "text",
                     "id": "profile_sns_x",
                     "label": "XのURL",
+                    "format": "url",
                     "placeholder": "https:// から始まるXのURLの入力"
                 },
                 {
                     "type": "text",
                     "id": "profile_sns_facebook",
                     "label": "FacebookのURL",
+                    "format": "url",
                     "placeholder": "https:// から始まるFacebookのURLの入力"
                 },
                 {
                     "type": "text",
                     "id": "profile_sns_instagram",
                     "label": "InstagramのURL",
+                    "format": "url",
                     "placeholder": "https:// から始まるInstagramのURLの入力"
                 },
                 {
                     "type": "text",
                     "id": "profile_sns_youtube",
                     "label": "YouTubeのチャンネルURL",
+                    "format": "url",
                     "placeholder": "https:// から始まるYouTubeのチャンネルURLの入力"
                 },
                 {
                     "type": "text",
                     "id": "profile_sns_github",
                     "label": "GithubのURL",
+                    "format": "url",
                     "placeholder": "https:// から始まるGithubのURLの入力"
                 }
             ]

--- a/resources/views/theme/components/forms.twig
+++ b/resources/views/theme/components/forms.twig
@@ -2,6 +2,7 @@
     uid: '',
     name: 'name',
     label: '',
+    format: 'text',
     value: '',
     placeholder: '',
     class: '',
@@ -15,7 +16,7 @@
         {% endif %}
         <input
             class="form-input"
-            type="text"
+            type="{{ options.format ?? 'text' }}"
             name="{{ options.name }}"
             value="{{ options.value }}"
             placeholder="{{ options.placeholder }}"

--- a/resources/views/theme/sections/customization-form.twig
+++ b/resources/views/theme/sections/customization-form.twig
@@ -46,6 +46,7 @@
                             uid: setting.uid,
                             name: name,
                             label: setting.label,
+                            format: setting.format,
                             value: value,
                             hint: setting.hint,
                             placeholder: setting.placeholder,

--- a/src/Http/Controller/Admin/ThemeCustomizationController.php
+++ b/src/Http/Controller/Admin/ThemeCustomizationController.php
@@ -61,6 +61,7 @@ class ThemeCustomizationController
         $errors = $validator->validate(
             body: (array) $request->getParsedBody(),
             schema: $this->activeTheme->meta->schema,
+            isStrict: false,
         );
 
         if ($errors->count()) {
@@ -99,6 +100,7 @@ class ThemeCustomizationController
         $errors = $validator->validate(
             body: (array) $request->getParsedBody(),
             schema: $this->activeTheme->meta->schema,
+            isStrict: true,
         );
 
         if ($errors->count()) {


### PR DESCRIPTION
## 概要

テーマをカスタマイズする時に、テキスト入力に対して入力フォーマットを指定できなかったため何でも入力できる状態でした。
ただ、カスタマイズ画面ではユーザーにURLやメールアドレスを入力させることが多いため、URLやメールアドレスについては、ある程度フォーマットに沿った形で入力させることが望ましいので、テキスト入力スキーマ設定に``url``または``email``などのフォーマット種別を指定することで、入力フォーム側で``<input type="email"/>``のような指定をできるようにしました。

以下のように、入力スキーマ設定に``format``設定をすることで、フォーマット種別を指定することができます。
``format``に何も指定しない場合は、フォーマット種別は``text``となります。
```json
{
    "type": "text",
    "format": "url",
}
```
