### PR TITLE
管理画面系の処理でスローするHttp例外の内容変更

### DIFF
--- a/src/Http/Middleware/GuideToInstallation.php
+++ b/src/Http/Middleware/GuideToInstallation.php
@@ -45,7 +45,7 @@ class GuideToInstallation implements MiddlewareInterface
         if (!$this->repository->isInstalled()) {
             return (new HtmlRenderer(
                 view('cms-tool::error.uninstalled'),
-                StatusCodeInterface::STATUS_UNAUTHORIZED,
+                StatusCodeInterface::STATUS_FORBIDDEN,
             ))->render(
                 $request,
                 $this->responseFactory->createResponse(),

--- a/src/Http/Middleware/VerifyActiveThemeCustomizability.php
+++ b/src/Http/Middleware/VerifyActiveThemeCustomizability.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Slim\Exception\HttpBadRequestException;
+use Slim\Exception\HttpForbiddenException;
 
 /**
  * Middleware to check if the active theme is customizable.
@@ -32,14 +32,14 @@ class VerifyActiveThemeCustomizability implements MiddlewareInterface
      * If unable to produce the response itself, it may delegate to the provided
      * request handler to do so.
      *
-     * @throws HttpBadRequestException
+     * @throws HttpForbiddenException
      */
     public function process(
         ServerRequestInterface $request,
         RequestHandlerInterface $handler,
     ): ResponseInterface {
         if (!$this->activeTheme->canBeCustomized()) {
-            throw new HttpBadRequestException(
+            throw new HttpForbiddenException(
                 request: $request,
                 message: 'The theme cannot be customized',
             );

--- a/src/Http/Middleware/VerifyActiveThemeCustomizability.php
+++ b/src/Http/Middleware/VerifyActiveThemeCustomizability.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Slim\Exception\HttpUnauthorizedException;
+use Slim\Exception\HttpBadRequestException;
 
 /**
  * Middleware to check if the active theme is customizable.
@@ -31,13 +31,15 @@ class VerifyActiveThemeCustomizability implements MiddlewareInterface
      * Processes an incoming server request in order to produce a response.
      * If unable to produce the response itself, it may delegate to the provided
      * request handler to do so.
+     *
+     * @throws HttpBadRequestException
      */
     public function process(
         ServerRequestInterface $request,
         RequestHandlerInterface $handler,
     ): ResponseInterface {
         if (!$this->activeTheme->canBeCustomized()) {
-            throw new HttpUnauthorizedException(
+            throw new HttpBadRequestException(
                 request: $request,
                 message: 'The theme cannot be customized',
             );


### PR DESCRIPTION
## 概要

Basic認証を掛ける管理画面系の処理でHttp認証例外をスローすると、ブラウザによってはBasic認証がリセットされるため、ステータスコードや例外を適切なものに変更しました。