### PR TITLE
フィード出力のルート設定をThemeRouteGroupHandlerに移動

### DIFF
--- a/src/Http/Routing/ThemeRouteGroupHandler.php
+++ b/src/Http/Routing/ThemeRouteGroupHandler.php
@@ -7,6 +7,7 @@ use Takemo101\CmsTool\Http\Action\Theme\HomeAction;
 use Takemo101\CmsTool\Support\Theme\ActiveThemeRouteRegister;
 use Slim\Interfaces\RouteCollectorProxyInterface as Proxy;
 use Slim\Interfaces\RouteGroupInterface;
+use Takemo101\CmsTool\Preset\Shared\Feed\FeedActionAndResponseRenderer;
 
 class ThemeRouteGroupHandler
 {
@@ -35,14 +36,41 @@ class ThemeRouteGroupHandler
      */
     public function __invoke(Proxy $proxy): void
     {
+        $this->registerBeforeBaseRoutes($proxy);
+
+        // Set routing for theme
+        $this->register->register($proxy);
+
+        $this->registerAfterBaseRoutes($proxy);
+    }
+
+    /**
+     * Register before base routes.
+     *
+     * @param Proxy $proxy
+     * @return void
+     */
+    private function registerBeforeBaseRoutes(Proxy $proxy): void
+    {
         $proxy->get(
             empty($proxy->getBasePath()) ? '/' : '',
             HomeAction::class,
         )->setName('home');
 
-        // Set routing for theme
-        $this->register->register($proxy);
+        $proxy->get(
+            '/feed',
+            FeedActionAndResponseRenderer::class,
+        )->setName('feed');
+    }
 
+    /**
+     * Register after base routes.
+     *
+     * @param Proxy $proxy
+     * @return void
+     */
+    private function registerAfterBaseRoutes(Proxy $proxy): void
+    {
         $proxy->get(
             '/{path:.+}',
             FixedPageAction::class,

--- a/src/function.php
+++ b/src/function.php
@@ -57,18 +57,17 @@ use Takemo101\CmsTool\Infra\Listener\CsrfGuardSetupListener;
 use Takemo101\CmsTool\Infra\Listener\DeleteRobotsTxtListener;
 use Takemo101\CmsTool\Infra\Listener\RequestParameterSetupListener;
 use Takemo101\CmsTool\Infra\Storage\LocalPublicStoragePath;
-use Takemo101\CmsTool\Preset\Shared\Feed\FeedActionAndResponseRenderer;
 use Takemo101\CmsTool\Support\Htmx\HtmxAccess;
 
 hook()
     ->onTyped(
-        fn (CommandCollection $commands) => $commands->add(
+        fn(CommandCollection $commands) => $commands->add(
             StorageLinkCommand::class,
             GenerateBasicAuthPasswordCommand::class,
         ),
     )
     ->onTyped(
-        fn (EventRegister $register) => $register
+        fn(EventRegister $register) => $register
             ->on(AdminSessionSetupListener::class)
             ->on(CsrfGuardSetupListener::class)
             ->on(RequestParameterSetupListener::class)
@@ -370,11 +369,6 @@ hook()
                         '/assets/{path:.+}',
                         ActiveThemeAssetAction::class,
                     )->setName(ActiveThemeAssetAction::RouteName);
-
-                    $proxy->get(
-                        '/feed',
-                        FeedActionAndResponseRenderer::class,
-                    )->setName('feed');
 
                     ThemeRouteGroupHandler::configure($proxy)
                         ->add(InsertTrackingCode::class)

--- a/src/function.php
+++ b/src/function.php
@@ -61,13 +61,13 @@ use Takemo101\CmsTool\Support\Htmx\HtmxAccess;
 
 hook()
     ->onTyped(
-        fn(CommandCollection $commands) => $commands->add(
+        fn (CommandCollection $commands) => $commands->add(
             StorageLinkCommand::class,
             GenerateBasicAuthPasswordCommand::class,
         ),
     )
     ->onTyped(
-        fn(EventRegister $register) => $register
+        fn (EventRegister $register) => $register
             ->on(AdminSessionSetupListener::class)
             ->on(CsrfGuardSetupListener::class)
             ->on(RequestParameterSetupListener::class)


### PR DESCRIPTION
## 概要

フィード出力のルートは、テーマを利用する上で必須のルートとなるので``ThemeRouteGroupHandler``にルート設定を移動しました。
``ThemeRouteGroupHandler``のルート登録処理をテーマ個別のルート設定の前と後で分割しました。
