### PR TITLE
``.env``ファイルの変数値を書き換える機能追加

### DIFF
--- a/modules/support/config/support.php
+++ b/modules/support/config/support.php
@@ -56,5 +56,6 @@ return [
         // CmsTool\Support\Translation\TranslationAccessor::class => CmsTool\Support\Translation\TranslationJsonFileAccessor::class,
         // CmsTool\Support\Translation\Translator::class => CmsTool\Support\Translation\DefaultTranslator::class,
         // CmsTool\Support\AccessLog\AccessLoggerFactory::class => CmsTool\Support\AccessLog\FileAccessLoggerFactory::class,
+        // CmsTool\Support\Dotenv\DotenvContentRepository::class => CmsTool\Support\Dotenv\LocalFileDotenvContentRepository::class,
     ],
 ];

--- a/modules/support/src/Dotenv/DotenvContent.php
+++ b/modules/support/src/Dotenv/DotenvContent.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace CmsTool\Support\Dotenv;
+
+/**
+ * ドットエンブファイルの内容を表すValueObject.
+ *
+ * @immutable
+ */
+readonly class DotenvContent
+{
+    /**
+     * @var DotenvValueReplacer
+     */
+    private readonly DotenvValueReplacer $replacer;
+
+    /**
+     * constructor
+     *
+     * @param string $value
+     */
+    public function __construct(
+        private string $value = '',
+    ) {
+        $this->replacer = new DotenvValueReplacer();
+    }
+
+    /**
+     * Replace the value of the given key.
+     *
+     * @param string $key
+     * @param string $value
+     * @return self
+     */
+    public function replace(
+        string $key,
+        string|int|float|bool|null $value,
+    ): self {
+        assert(
+            empty($key) === false,
+            'The key must not be empty.',
+        );
+
+        return new self(
+            $this->replacer->replace(
+                content: $this->value,
+                key: $key,
+                value: $value,
+            ),
+        );
+    }
+
+    /**
+     * Get the content value.
+     *
+     * @return string
+     */
+    public function value(): string
+    {
+        return $this->value;
+    }
+}

--- a/modules/support/src/Dotenv/DotenvContentRepository.php
+++ b/modules/support/src/Dotenv/DotenvContentRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CmsTool\Support\Dotenv;
+
+interface DotenvContentRepository
+{
+    /**
+     * Find the dotenv content.
+     *
+     * @return DotenvContent|null
+     */
+    public function find(): ?DotenvContent;
+
+    /**
+     * Save the dotenv content.
+     *
+     * @param DotenvContent $content
+     * @return void
+     */
+    public function save(DotenvContent $content): void;
+}

--- a/modules/support/src/Dotenv/DotenvValueReplacer.php
+++ b/modules/support/src/Dotenv/DotenvValueReplacer.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace CmsTool\Support\Dotenv;
+
+/**
+ * Replace the value corresponding to the dotenv string key.
+ */
+class DotenvValueReplacer
+{
+    /**
+     * Replace the value in the content.
+     *
+     * @param string $content
+     * @param string $key
+     * @param string|int|float|bool|null $value
+     * @return string
+     */
+    public function replace(
+        string $content,
+        string $key,
+        string|int|float|bool|null $value,
+    ): string {
+        if ($value === null) {
+            return $this->replaceKeyInContent(
+                content: $content,
+                key: $key,
+                value: 'null',
+            );
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return $this->replaceKeyInContent(
+                content: $content,
+                key: $key,
+                value: (string) $value,
+            );
+        }
+
+        if (is_bool($value)) {
+            return $this->replaceKeyInContent(
+                content: $content,
+                key: $key,
+                value: $value ? 'true' : 'false',
+            );
+        }
+
+        return $this->replaceString($content, $key, $value);
+    }
+
+    /**
+     * Replace the string value in the content.
+     *
+     * @param string $content
+     * @param string $key
+     * @param string $value
+     * @return string
+     */
+    private function replaceString(
+        string $content,
+        string $key,
+        string $value,
+    ): string {
+        // Replace $ with \$ to avoid error
+        $escapedValue = str_replace('$', '\$', $value);
+
+        // Wrap the value with double quotes
+        $stringValue = strlen($escapedValue) > 0
+            ? sprintf('"%s"', $escapedValue)
+            : '';
+
+        return $this->replaceKeyInContent(
+            content: $content,
+            key: $key,
+            value: $stringValue,
+        );
+    }
+
+    /**
+     * Replace the content.
+     *
+     * @param string $content
+     * @param string $key
+     * @param string $value
+     * @return string
+     */
+    private function replaceKeyInContent(
+        string $content,
+        string $key,
+        string $value,
+    ): string {
+        $upperKey = strtoupper($key);
+
+        $random = bin2hex(random_bytes(8));
+        $replaceKey = "### ----{$random}---- ###";
+
+        /** @var string|null */
+        $replacedContent = preg_replace(
+            sprintf('/%s=.*$/m', $upperKey),
+            $replaceKey,
+            $content,
+        );
+
+        if ($replacedContent === null) {
+            return $content;
+        }
+
+        $replacedContent = str_replace(
+            $replaceKey,
+            sprintf('%s=%s', $key, $value),
+            $replacedContent,
+        );
+
+        return $replacedContent;
+    }
+}

--- a/modules/support/src/Dotenv/LocalFileDotenvContentRepository.php
+++ b/modules/support/src/Dotenv/LocalFileDotenvContentRepository.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace CmsTool\Support\Dotenv;
+
+use RuntimeException;
+use Takemo101\Chubby\Filesystem\LocalFilesystem;
+use Takemo101\Chubby\Support\ApplicationPath;
+use Takemo101\Chubby\Support\ApplicationSummary;
+
+class LocalFileDotenvContentRepository implements DotenvContentRepository
+{
+    public const DotenvName = '.env';
+
+    /**
+     * constructor
+     *
+     * @param ApplicationPath $path
+     * @param ApplicationSummary $summary
+     * @param LocalFilesystem $filesystem
+     */
+    public function __construct(
+        private readonly ApplicationPath $path,
+        private readonly ApplicationSummary $summary,
+        private readonly LocalFilesystem $filesystem,
+    ) {
+        //
+    }
+
+    /**
+     * Find the dotenv content.
+     *
+     * @return DotenvContent|null
+     * @throws RuntimeException
+     */
+    public function find(): ?DotenvContent
+    {
+        $paths = $this->createDotenvPaths();
+
+        foreach ($paths as $path) {
+            if ($this->filesystem->exists($path)) {
+                return new DotenvContent(
+                    $this->filesystem->read($path) ?? throw new RuntimeException("Failed to read the dotenv file: {$path}"),
+                );
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Save the dotenv content.
+     *
+     * @param DotenvContent $content
+     * @return void
+     * @throws RuntimeException
+     */
+    public function save(DotenvContent $content): void
+    {
+        $paths = $this->createDotenvPaths();
+
+        foreach ($paths as $path) {
+            if ($this->filesystem->exists($path)) {
+                $this->filesystem->write($path, $content->value()) ?: throw new RuntimeException("Failed to write the dotenv file: {$path}");
+            }
+        }
+    }
+
+    /**
+     * Create dotenv paths.
+     *
+     * @return string[]
+     */
+    private function createDotenvPaths(): array
+    {
+        $name = self::DotenvName;
+        $enviroment = $this->summary->getEnvironment();
+
+        return [
+            $this->path->getBasePath($name),
+            $this->path->getBasePath("{$name}.{$enviroment}"),
+        ];
+    }
+}

--- a/modules/support/src/SupportProvider.php
+++ b/modules/support/src/SupportProvider.php
@@ -6,6 +6,8 @@ use CmsTool\Support\AccessLog\AccessLogger;
 use CmsTool\Support\AccessLog\AccessLoggerFactory;
 use CmsTool\Support\AccessLog\Command\AccessLogCleanCommand;
 use CmsTool\Support\AccessLog\FileAccessLoggerFactory;
+use CmsTool\Support\Dotenv\DotenvContentRepository;
+use CmsTool\Support\Dotenv\LocalFileDotenvContentRepository;
 use CmsTool\Support\Encrypt\Command\GenerateEncryptKeyCommand;
 use CmsTool\Support\Encrypt\DefaultEncrypter;
 use CmsTool\Support\Encrypt\EncryptCipher;
@@ -80,6 +82,7 @@ class SupportProvider implements Provider
                     Translator::class => DefaultTranslator::class,
                     AccessLoggerFactory::class => FileAccessLoggerFactory::class,
                     FeedGenerator::class => Rss2FeedGenerator::class,
+                    DotenvContentRepository::class => LocalFileDotenvContentRepository::class,
                 ],
                 configKeyPrefix: 'support',
             )
@@ -114,7 +117,7 @@ class SupportProvider implements Provider
         $hook = $container->get(Hook::class);
 
         $hook->onTyped(
-            fn (CommandCollection $commands) => $commands->add(
+            fn(CommandCollection $commands) => $commands->add(
                 GenerateEncryptKeyCommand::class,
                 AddTranslationTextCommand::class,
                 AccessLogCleanCommand::class,
@@ -189,7 +192,7 @@ class SupportProvider implements Provider
                     ->setTranslationDomain(SymfonyTranslationProxy::ValidationDomain)
                     ->getValidator();
             },
-            ObjectMapper::class => fn () => new ObjectMapperUsingReflection(),
+            ObjectMapper::class => fn() => new ObjectMapperUsingReflection(),
         ]);
     }
 
@@ -205,7 +208,7 @@ class SupportProvider implements Provider
     public function registerAccessLog(Definitions $definitions): void
     {
         $definitions->add([
-            AccessLogger::class => fn (AccessLoggerFactory $factory) => $factory->create(),
+            AccessLogger::class => fn(AccessLoggerFactory $factory) => $factory->create(),
         ]);
     }
 }

--- a/modules/support/tests/Dotenv/DotenvValueReplacerTest.php
+++ b/modules/support/tests/Dotenv/DotenvValueReplacerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use CmsTool\Support\Dotenv\DotenvValueReplacer;
+
+describe(
+    'DotenvValueReplacer',
+    function () {
+
+        it('replaces null value in content', function () {
+            $content = 'DB_HOST=localhost
+DB_PORT=3306
+DB_USERNAME=root
+DB_PASSWORD=null';
+
+            $replacer = new DotenvValueReplacer();
+            $replacedContent = $replacer->replace($content, 'DB_PASSWORD', null);
+
+            expect($replacedContent)->toBe('DB_HOST=localhost
+DB_PORT=3306
+DB_USERNAME=root
+DB_PASSWORD=null');
+        });
+
+        it('replaces integer value in content', function () {
+            $content = 'APP_PORT=8000';
+
+            $replacer = new DotenvValueReplacer();
+            $replacedContent = $replacer->replace($content, 'APP_PORT', 8080);
+
+            expect($replacedContent)->toBe('APP_PORT=8080');
+        });
+
+        it('replaces float value in content', function () {
+            $content = 'PI=3.14';
+
+            $replacer = new DotenvValueReplacer();
+            $replacedContent = $replacer->replace($content, 'PI', 3.14159);
+
+            expect($replacedContent)->toBe('PI=3.14159');
+        });
+
+        it('replaces boolean value in content', function () {
+            $content = 'DEBUG=false';
+
+            $replacer = new DotenvValueReplacer();
+            $replacedContent = $replacer->replace($content, 'DEBUG', true);
+
+            expect($replacedContent)->toBe('DEBUG=true');
+        });
+
+        it('replaces string value in content', function () {
+            $content = 'APP_NAME=MyApp';
+
+            $replacer = new DotenvValueReplacer();
+            $replacedContent = $replacer->replace($content, 'APP_NAME', 'NewApp');
+
+            expect($replacedContent)->toBe('APP_NAME="NewApp"');
+        });
+    }
+)->group('DotenvValueReplacer', 'dotenv');

--- a/modules/support/tests/Dotenv/LocalFileDotenvContentRepositoryTest.php
+++ b/modules/support/tests/Dotenv/LocalFileDotenvContentRepositoryTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use CmsTool\Support\Dotenv\DotenvContent;
+use CmsTool\Support\Dotenv\LocalFileDotenvContentRepository;
+use Takemo101\Chubby\Filesystem\LocalFilesystem;
+use Takemo101\Chubby\Support\ApplicationPath;
+use Takemo101\Chubby\Support\ApplicationSummary;
+use Takemo101\Chubby\Http\Uri\ApplicationUri;
+use Mockery as m;
+
+describe(
+    'LocalFileDotenvContentRepository',
+    function () {
+        it('finds the dotenv content if the file exists', function () {
+            $path = new ApplicationPath(
+                basePath: '/path/to',
+            );
+            $summary = new ApplicationSummary(
+                uri: m::mock(ApplicationUri::class),
+                env: 'testing',
+            );
+            $filesystem = m::mock(LocalFilesystem::class);
+
+            $repository = new LocalFileDotenvContentRepository($path, $summary, $filesystem);
+
+            $content = new DotenvContent('KEY=value');
+
+            $filesystem->shouldReceive('exists')->with('/path/to/.env')->andReturn(false);
+            $filesystem->shouldReceive('exists')->with('/path/to/.env.testing')->andReturn(true);
+            $filesystem->shouldReceive('read')->with('/path/to/.env.testing')->andReturn('KEY=value');
+
+            $result = $repository->find();
+
+            expect($result)->toBeInstanceOf(DotenvContent::class);
+            expect($result->value())->toBe('KEY=value');
+        });
+
+        it('returns null if the dotenv file does not exist', function () {
+            $path = new ApplicationPath(
+                basePath: '/path/to',
+            );
+            $summary = new ApplicationSummary(
+                uri: m::mock(ApplicationUri::class),
+                env: 'testing',
+            );
+            $filesystem = m::mock(LocalFilesystem::class);
+
+            $repository = new LocalFileDotenvContentRepository($path, $summary, $filesystem);
+
+            $filesystem->shouldReceive('exists')->with('/path/to/.env')->andReturn(false);
+            $filesystem->shouldReceive('exists')->with('/path/to/.env.testing')->andReturn(false);
+
+            $result = $repository->find();
+
+            expect($result)->toBeNull();
+        });
+
+        it('saves the dotenv content to the existing file', function () {
+            $path = new ApplicationPath(
+                basePath: '/path/to',
+            );
+            $summary = new ApplicationSummary(
+                uri: m::mock(ApplicationUri::class),
+                env: 'testing',
+            );
+            $filesystem = m::mock(LocalFilesystem::class);
+
+            $repository = new LocalFileDotenvContentRepository($path, $summary, $filesystem);
+
+            $content = new DotenvContent('KEY=value');
+
+            $filesystem->shouldReceive('exists')->with('/path/to/.env')->andReturn(false);
+            $filesystem->shouldReceive('exists')->with('/path/to/.env.testing')->andReturn(true);
+            $filesystem->shouldReceive('write')
+                ->with('/path/to/.env.testing', 'KEY=value')
+                ->andReturn(true)
+                ->once();
+
+            $repository->save($content);
+        });
+
+        it('throws an exception when failed to write the dotenv file', function () {
+            $path = new ApplicationPath(
+                basePath: '/path/to',
+            );
+            $summary = new ApplicationSummary(
+                uri: m::mock(ApplicationUri::class),
+                env: 'testing',
+            );
+            $filesystem = m::mock(LocalFilesystem::class);
+
+            $repository = new LocalFileDotenvContentRepository($path, $summary, $filesystem);
+
+            $content = new DotenvContent('KEY=value');
+
+            $filesystem->shouldReceive('exists')->with('/path/to/.env')->andReturn(false);
+            $filesystem->shouldReceive('exists')->with('/path/to/.env.testing')->andReturn(true);
+            $filesystem->shouldReceive('write')->with('/path/to/.env.testing', 'KEY=value')->andReturn(false);
+
+            expect(function () use ($repository, $content) {
+                $repository->save($content);
+            })->toThrow(RuntimeException::class, 'Failed to write the dotenv file: /path/to/.env.testing');
+        });
+    },
+)->group('LocalFileDotenvContentRepository', 'dotenv');


### PR DESCRIPTION
## 概要

今まで、``Command``クラス内で``.env``の変数値を書き換える処理を都度記述していたのですが、今回サポートモジュールに共通機能として、書き換えの実装である``DotenvContentRepository``を追加しました。
現在、変数値の書き換えが発生している部分は``DotenvContentRepository``に依存する形の実装に変更しました。
