### PR TITLE
``ImmutableArrayObjectable``の型ヒントにジェネリクスが設定されてなかったので追加

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,6 @@
 parameters:
     level: max
     paths:
-        - app
+        - src
 
     reportUnmatchedIgnoredErrors: true

--- a/src/Infra/Saloon/QueryService/SaloonMicroCmsContentQueryService.php
+++ b/src/Infra/Saloon/QueryService/SaloonMicroCmsContentQueryService.php
@@ -107,7 +107,7 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
             return null;
         }
 
-        /** @var ImmutableArrayObjectable */
+        /** @var ImmutableArrayObjectable<string,mixed> */
         $dto = $response->dto();
 
         return $dto;
@@ -194,7 +194,7 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
             return null;
         }
 
-        /** @var ImmutableArrayObjectable */
+        /** @var ImmutableArrayObjectable<string,mixed> */
         $dto = $response->dto();
 
         return $dto;
@@ -250,12 +250,12 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
             enabled: $cache,
         );
 
-        /** @var array<string,mixed> */
+        /** @var array<string,mixed>[] */
         $contents = $json['contents'] ?? [];
 
-        /** @var ImmutableArrayObjectable[] */
+        /** @var ImmutableArrayObjectable<string,mixed>[] */
         $contents = array_map(
-            fn (array $content) => ImmutableArrayObject::of($content),
+            fn(array $content) => ImmutableArrayObject::of($content),
             $contents,
         );
 
@@ -314,12 +314,12 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
             enabled: $cache,
         );
 
-        /** @var array<string,mixed> */
+        /** @var array<string,mixed>[] */
         $contents = $json['contents'] ?? [];
 
-        /** @var ImmutableArrayObjectable[] */
+        /** @var ImmutableArrayObjectable<string,mixed>[] */
         $contents = array_map(
-            fn (array $content) => ImmutableArrayObject::of($content),
+            fn(array $content) => ImmutableArrayObject::of($content),
             $contents,
         );
 

--- a/src/Infra/Saloon/QueryService/SaloonMicroCmsContentQueryService.php
+++ b/src/Infra/Saloon/QueryService/SaloonMicroCmsContentQueryService.php
@@ -255,7 +255,7 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
 
         /** @var ImmutableArrayObjectable<string,mixed>[] */
         $contents = array_map(
-            fn(array $content) => ImmutableArrayObject::of($content),
+            fn (array $content) => ImmutableArrayObject::of($content),
             $contents,
         );
 
@@ -319,7 +319,7 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
 
         /** @var ImmutableArrayObjectable<string,mixed>[] */
         $contents = array_map(
-            fn(array $content) => ImmutableArrayObject::of($content),
+            fn (array $content) => ImmutableArrayObject::of($content),
             $contents,
         );
 

--- a/src/Preset/MicroCms/Blog/BlogFeedCreator.php
+++ b/src/Preset/MicroCms/Blog/BlogFeedCreator.php
@@ -21,7 +21,7 @@ use DateTimeImmutable;
 use Takemo101\CmsTool\Support\ArrayObject\ImmutableArrayObjectable;
 
 /**
- * @phpstan-type ContentData = ImmutableArrayObjectable&object{
+ * @phpstan-type ContentData = ImmutableArrayObjectable<string,mixed>&object{
  *   title: string,
  *   publishedAt: string,
  *   updatedAt: string,

--- a/src/Preset/MicroCms/Blog/BlogHook.php
+++ b/src/Preset/MicroCms/Blog/BlogHook.php
@@ -47,7 +47,7 @@ class BlogHook implements ThemeHook
                     $extension = ImmutableArrayObject::of($theme->meta->extension);
 
                     /**
-                     * @var ImmutableArrayObjectable&object{
+                     * @var ImmutableArrayObjectable<string,mixed>&object{
                      *  blog: string,
                      *  category: string,
                      *  tag: string,
@@ -60,7 +60,7 @@ class BlogHook implements ThemeHook
                     ]);
 
                     /**
-                     * @var ImmutableArrayObjectable&object{
+                     * @var ImmutableArrayObjectable<string,mixed>&object{
                      *  category: string,
                      *  tag: string,
                      * }

--- a/src/Preset/MicroCms/Blog/BlogRoute.php
+++ b/src/Preset/MicroCms/Blog/BlogRoute.php
@@ -28,7 +28,7 @@ class BlogRoute implements ThemeRoute
         $order = 'publishedAt';
 
         /**
-         * @var ImmutableArrayObjectable&object{
+         * @var ImmutableArrayObjectable<string,mixed>&object{
          *  endpoints: object{
          *   blog: string,
          *   category: string,

--- a/src/Preset/MicroCms/Blog/RelatedBlogAccessor.php
+++ b/src/Preset/MicroCms/Blog/RelatedBlogAccessor.php
@@ -35,7 +35,7 @@ class RelatedBlogAccessor
      *
      * @param string $id
      * @param integer $limit
-     * @return ImmutableArrayObjectable[]
+     * @return ImmutableArrayObjectable<string,mixed>[]
      */
     public function __invoke(
         string $id,

--- a/src/Preset/MicroCms/Shared/Accessor/TaxonomiesAccessor.php
+++ b/src/Preset/MicroCms/Shared/Accessor/TaxonomiesAccessor.php
@@ -33,7 +33,7 @@ class TaxonomiesAccessor
      * @param integer $limit
      * @param string|null $id
      * @param string|null $orders
-     * @return ImmutableArrayObjectable[]
+     * @return ImmutableArrayObjectable<string,mixed>[]
      */
     public function __invoke(int $limit = self::DefaultLimit, ?string $id = null, ?string $orders = null): array
     {

--- a/src/Preset/MicroCms/Shared/Action/ContentDetailAction.php
+++ b/src/Preset/MicroCms/Shared/Action/ContentDetailAction.php
@@ -98,7 +98,7 @@ class ContentDetailAction
      *
      * @param MicroCmsContentQueryService $queryService
      * @param ArrayObject $content
-     * @return Closure():array{0: ?ImmutableArrayObjectable, 1: ?ImmutableArrayObjectable}
+     * @return Closure():array{0: ?ImmutableArrayObjectable<string,mixed>, 1: ?ImmutableArrayObjectable<string,mixed>}
      */
     private function createPrevAndNextGenerator(
         MicroCmsContentQueryService $queryService,

--- a/src/Preset/MicroCms/Shared/ViewModel/ContentDetailHelper.php
+++ b/src/Preset/MicroCms/Shared/ViewModel/ContentDetailHelper.php
@@ -33,7 +33,7 @@ class ContentDetailHelper
     {
         [$prev, $next] = ($this->generator)();
 
-        return new class($prev, $next) {
+        return new class ($prev, $next) {
             use HasCamelCaseAccess;
 
             /**

--- a/src/Preset/MicroCms/Shared/ViewModel/ContentDetailHelper.php
+++ b/src/Preset/MicroCms/Shared/ViewModel/ContentDetailHelper.php
@@ -13,7 +13,7 @@ class ContentDetailHelper
     /**
      * constructor
      *
-     * @param Closure():array{0: ?ImmutableArrayObjectable, 1: ?ImmutableArrayObjectable} $generator [0 => prev, 1 => next]
+     * @param Closure():array{0: ?ImmutableArrayObjectable<string,mixed>, 1: ?ImmutableArrayObjectable<string,mixed>} $generator [0 => prev, 1 => next]
      */
     public function __construct(
         private readonly Closure $generator,
@@ -25,22 +25,22 @@ class ContentDetailHelper
      * Get the next and previous content.
      *
      * @return object {
-     *   prev: ?ImmutableArrayObjectable,
-     *   next: ?ImmutableArrayObjectable,
+     *   prev: ?ImmutableArrayObjectable<string,mixed>,
+     *   next: ?ImmutableArrayObjectable<string,mixed>,
      * }
      */
     public function getPrevNext(): object
     {
         [$prev, $next] = ($this->generator)();
 
-        return new class ($prev, $next) {
+        return new class($prev, $next) {
             use HasCamelCaseAccess;
 
             /**
              * constructor
              *
-             * @param ImmutableArrayObjectable|null $prev
-             * @param ImmutableArrayObjectable|null $next
+             * @param ImmutableArrayObjectable<string,mixed>|null $prev
+             * @param ImmutableArrayObjectable<string,mixed>|null $next
              */
             public function __construct(
                 public readonly ?ImmutableArrayObjectable $prev,

--- a/src/Preset/MicroCms/Shared/ViewModel/ContentDetailPage.php
+++ b/src/Preset/MicroCms/Shared/ViewModel/ContentDetailPage.php
@@ -11,7 +11,7 @@ class ContentDetailPage extends ViewModel
     /**
      * constructor
      *
-     * @param ImmutableArrayObjectable $content
+     * @param ImmutableArrayObjectable<string,mixed> $content
      * @param Closure():array{0:?ArrayObject, 1:?ArrayObject} $prevAndNextContentsGenerator [0 => prev, 1 => next]
      * @param bool $isDraft
      */

--- a/src/Preset/MicroCms/Shared/ViewModel/ContentIndexPage.php
+++ b/src/Preset/MicroCms/Shared/ViewModel/ContentIndexPage.php
@@ -21,7 +21,7 @@ class ContentIndexPage extends ViewModel
     }
 
     /**
-     * @return ImmutableArrayObjectable[]
+     * @return ImmutableArrayObjectable<string,mixed>[]
      */
     public function contents(): array
     {

--- a/src/Preset/MicroCms/Shared/ViewModel/TaxonomyIndexPage.php
+++ b/src/Preset/MicroCms/Shared/ViewModel/TaxonomyIndexPage.php
@@ -12,7 +12,7 @@ class TaxonomyIndexPage extends ViewModel
     /**
      * constructor
      *
-     * @param ImmutableArrayObjectable $taxonomy
+     * @param ImmutableArrayObjectable<string,mixed> $taxonomy
      * @param MicroCmsContentGetListResult $result
      */
     public function __construct(
@@ -23,7 +23,7 @@ class TaxonomyIndexPage extends ViewModel
     }
 
     /**
-     * @return ImmutableArrayObjectable[]
+     * @return ImmutableArrayObjectable<string,mixed>[]
      */
     public function contents(): array
     {

--- a/src/Support/Accessor/ActiveThemeCustomizationAccessor.php
+++ b/src/Support/Accessor/ActiveThemeCustomizationAccessor.php
@@ -23,7 +23,7 @@ class ActiveThemeCustomizationAccessor
     }
 
     /**
-     * @return ImmutableArrayObjectable
+     * @return ImmutableArrayObjectable<string,array<string,mixed>>
      */
     public function __invoke(): ImmutableArrayObjectable
     {

--- a/src/Support/Accessor/ServerRequestAccessor.php
+++ b/src/Support/Accessor/ServerRequestAccessor.php
@@ -22,7 +22,7 @@ class ServerRequestAccessor
     }
 
     /**
-     * @return ImmutableArrayObjectable
+     * @return ImmutableArrayObjectable<string,mixed>
      */
     public function __invoke(): ImmutableArrayObjectable
     {

--- a/src/Support/ArrayObject/ArrayKeySearcher.php
+++ b/src/Support/ArrayObject/ArrayKeySearcher.php
@@ -42,10 +42,15 @@ class ArrayKeySearcher
         }
 
         foreach ($this->transformers as $transformer) {
-            $key = $transformer($key);
+            $transformed = $transformer($key);
 
-            if (array_key_exists($key, $items)) {
-                return $key;
+            // If the key is the same, skip it.
+            if ($transformed === $key) {
+                continue;
+            }
+
+            if (array_key_exists($transformed, $items)) {
+                return $transformed;
             }
         }
 
@@ -62,6 +67,8 @@ class ArrayKeySearcher
         return new self(
             fn (string $key) => u($key)->camel()->toString(),
             fn (string $key) => u($key)->snake()->toString(),
+            // Add a underscore to the beginning of the key.
+            fn (string $key) => "_{$key}",
         );
     }
 }

--- a/src/Support/ArrayObject/ImmutableArrayObject.php
+++ b/src/Support/ArrayObject/ImmutableArrayObject.php
@@ -29,7 +29,7 @@ class ImmutableArrayObject extends ImmutableArrayObjectable
      */
     public function get(string $name, mixed $default = null): mixed
     {
-        return Arr::get($this->items, $name, $default);
+        return Arr::get($this->__items, $name, $default);
     }
 
     /**
@@ -41,11 +41,11 @@ class ImmutableArrayObject extends ImmutableArrayObjectable
     {
         // If the offset is an numeric, it is treated as an index.
         if (is_numeric($offset)) {
-            return $this->items[$offset] ?? null;
+            return $this->__items[$offset] ?? null;
         }
 
-        if ($key = $this->searcher->search($offset, $this->items)) {
-            return $this->items[$key] ?? throw new OutOfBoundsException('offset not found');
+        if ($key = $this->searcher->search($offset, $this->__items)) {
+            return $this->__items[$key] ?? throw new OutOfBoundsException('offset not found');
         }
 
         return null;
@@ -58,9 +58,9 @@ class ImmutableArrayObject extends ImmutableArrayObjectable
     {
         // If the offset is an numeric, it is treated as an index.
         if (is_numeric($offset)) {
-            return array_key_exists($offset, $this->items);
+            return array_key_exists($offset, $this->__items);
         }
 
-        return $this->searcher->search($offset, $this->items) !== false;
+        return $this->searcher->search($offset, $this->__items) !== false;
     }
 }

--- a/src/Support/ArrayObject/ImmutableArrayObjectable.php
+++ b/src/Support/ArrayObject/ImmutableArrayObjectable.php
@@ -22,13 +22,20 @@ use OutOfBoundsException;
 abstract class ImmutableArrayObjectable implements IteratorAggregate, ArrayAccess, Countable, JsonSerializable, Arrayable
 {
     /**
+     * @var array<TKey,TValue>
+     */
+    protected readonly array $__items;
+
+    /**
      * constructor
      *
      * @param array<TKey,TValue> $items
      */
     final public function __construct(
-        protected readonly array $items = [],
+        array $items = [],
     ) {
+        $this->__items = $items;
+
         $this->__init();
     }
 
@@ -89,7 +96,7 @@ abstract class ImmutableArrayObjectable implements IteratorAggregate, ArrayAcces
      */
     final public function getIterator(): Traversable
     {
-        return new ArrayIterator($this->items);
+        return new ArrayIterator($this->__items);
     }
 
     /**
@@ -140,7 +147,7 @@ abstract class ImmutableArrayObjectable implements IteratorAggregate, ArrayAcces
      */
     final public function count(): int
     {
-        return count($this->items);
+        return count($this->__items);
     }
 
     /**
@@ -160,7 +167,7 @@ abstract class ImmutableArrayObjectable implements IteratorAggregate, ArrayAcces
 
                 return $item;
             },
-            $this->items,
+            $this->__items,
         );
     }
 
@@ -172,10 +179,10 @@ abstract class ImmutableArrayObjectable implements IteratorAggregate, ArrayAcces
     final public function toArray(): array
     {
         return array_map(
-            fn($item) => $item instanceof Arrayable
+            fn ($item) => $item instanceof Arrayable
                 ? $item->toArray()
                 : $item,
-            $this->items,
+            $this->__items,
         );
     }
 

--- a/src/Support/ArrayObject/ImmutableArrayObjectable.php
+++ b/src/Support/ArrayObject/ImmutableArrayObjectable.php
@@ -172,7 +172,7 @@ abstract class ImmutableArrayObjectable implements IteratorAggregate, ArrayAcces
     final public function toArray(): array
     {
         return array_map(
-            fn ($item) => $item instanceof Arrayable
+            fn($item) => $item instanceof Arrayable
                 ? $item->toArray()
                 : $item,
             $this->items,
@@ -182,8 +182,11 @@ abstract class ImmutableArrayObjectable implements IteratorAggregate, ArrayAcces
     /**
      * Constructor of static method.
      *
-     * @param array<TKey,TValue> $items
-     * @return static
+     * @template TK as array-key
+     * @template TV
+     *
+     * @param array<TK,TV> $items
+     * @return static<TK,TV>
      */
     final public static function of(
         array $items = [],

--- a/src/Support/BasicAuth/BasicAuthHeaderParser.php
+++ b/src/Support/BasicAuth/BasicAuthHeaderParser.php
@@ -13,7 +13,7 @@ class BasicAuthHeaderParser
      * If the header is invalid, it returns false.
      *
      * @param string $header
-     * @return (ImmutableArrayObjectable&object{
+     * @return (ImmutableArrayObjectable<string,mixed>&object{
      *   username: string,
      *   password: string,
      * })|false
@@ -51,7 +51,7 @@ class BasicAuthHeaderParser
      * If the header is invalid, it returns false.
      *
      * @param ServerRequestInterface $request
-     * @return (ImmutableArrayObjectable&object{
+     * @return (ImmutableArrayObjectable<string,mixed>&object{
      *   username: string,
      *   password: string,
      * })|false

--- a/src/Support/BasicAuth/BasicAuthUsers.php
+++ b/src/Support/BasicAuth/BasicAuthUsers.php
@@ -52,7 +52,7 @@ class BasicAuthUsers
      * If the user does not exist, it returns false.
      *
      * @param string $username
-     * @return ImmutableArrayObjectable&object{
+     * @return ImmutableArrayObjectable<string,mixed>&object{
      *   username: string,
      *   password: string,
      * }

--- a/src/Support/Htmlable/HtmlSectionAccessor.php
+++ b/src/Support/Htmlable/HtmlSectionAccessor.php
@@ -19,7 +19,7 @@ class HtmlSectionAccessor
     }
 
     /**
-     * @return ImmutableArrayObjectable&object{
+     * @return ImmutableArrayObjectable<string,mixed>&object{
      *    head: HeadHtmls
      * }
      */

--- a/src/UseCase/MicroCms/QueryService/Content/MicroCmsContentGetListResult.php
+++ b/src/UseCase/MicroCms/QueryService/Content/MicroCmsContentGetListResult.php
@@ -10,7 +10,7 @@ readonly class MicroCmsContentGetListResult
     /**
      * constructor
      *
-     * @param ImmutableArrayObjectable[] $contents
+     * @param ImmutableArrayObjectable<string,mixed>[] $contents
      * @param ContentPaginator $paginator
      */
     public function __construct(

--- a/src/UseCase/MicroCms/QueryService/Content/MicroCmsContentQueryService.php
+++ b/src/UseCase/MicroCms/QueryService/Content/MicroCmsContentQueryService.php
@@ -13,7 +13,7 @@ interface MicroCmsContentQueryService
      * @param string $endpoint
      * @param MicroCmsContentGetOneQuery $query
      * @param bool $cache
-     * @return ImmutableArrayObjectable|null
+     * @return ImmutableArrayObjectable<string,mixed>|null
      */
     public function getSingle(
         string $endpoint,
@@ -27,7 +27,7 @@ interface MicroCmsContentQueryService
      * @param string $endpoint
      * @param string $draftKey
      * @param MicroCmsContentGetOneQuery $query
-     * @return ImmutableArrayObjectable|null
+     * @return ImmutableArrayObjectable<string,mixed>|null
      */
     public function getSingleDraft(
         string $endpoint,
@@ -43,7 +43,7 @@ interface MicroCmsContentQueryService
      * @param string $id
      * @param MicroCmsContentGetOneQuery $query
      * @param bool $cache
-     * @return ImmutableArrayObjectable|null
+     * @return ImmutableArrayObjectable<string,mixed>|null
      */
     public function getOne(
         string $endpoint,
@@ -59,7 +59,7 @@ interface MicroCmsContentQueryService
      * @param string $id
      * @param string $draftKey
      * @param MicroCmsContentGetOneQuery $query
-     * @return ImmutableArrayObjectable|null
+     * @return ImmutableArrayObjectable<string,mixed>|null
      */
     public function getOneDraft(
         string $endpoint,
@@ -74,7 +74,7 @@ interface MicroCmsContentQueryService
      * @param string $endpoint
      * @param MicroCmsContentGetOneQuery $query
      * @param bool $cache
-     * @return ImmutableArrayObjectable|null
+     * @return ImmutableArrayObjectable<string,mixed>|null
      */
     public function getFirst(
         string $endpoint,

--- a/tests/Support/ArrayObject/ImmutableArrayObjectTest.php
+++ b/tests/Support/ArrayObject/ImmutableArrayObjectTest.php
@@ -103,6 +103,20 @@ describe(
             expect($immutableArray['key_of'])->toBe($data['keyOf']);
         });
 
+        it('should get the value of a underscore-prefixed key from the immutable array object using offsetGet', function () {
+            $data = [
+                '_id' => 'value',
+                '_key' => 'value',
+            ];
+
+            $immutableArray = ImmutableArrayObject::of($data);
+
+            expect($immutableArray->id)->toBe($data['_id']);
+            expect($immutableArray['id'])->toBe($data['_id']);
+            expect($immutableArray->key)->toBe($data['_key']);
+            expect($immutableArray['key'])->toBe($data['_key']);
+        });
+
         it('should get the value of a camel case key from the immutable array object using offsetGet', function () {
             $data = [
                 'all_of' => 'value',


### PR DESCRIPTION
## 概要

``ImmutableArrayObjectable``の型ヒントにジェネリクスが設定されてなかったので追加した。
あと、``ImmutableArrayObject``のキーにアンダースコアを接頭辞としたキーの値を、接頭辞なしの名前で参照できるように修正した。