### PR TITLE
キャッシュを種類ごとに管理する機能追加

### DIFF
--- a/config/system.php
+++ b/config/system.php
@@ -58,4 +58,28 @@ return [
             env('BASIC_AUTH_USERNAME', 'admin') => env('BASIC_AUTH_PASSWORD', 'admin'),
         ],
     ],
+
+    // Content api cache settings
+    'api_cache' => [
+
+        // Whether to enable cache
+        // This setting is reflected when using ApiMemoCache
+        'enabled' => (bool) env(
+            'API_CACHE_ENABLED',
+            env('CACHE_ENABLED', true),
+        ),
+
+        // Default lifetime seconds
+        'lifetime' => (int) env(
+            'API_CACHE_LIFETIME',
+            env('CACHE_LIFETIME', 21600 * 2), // 6 hours
+        ),
+
+        // FilesystemAdapter options
+        'filesystem' => [
+
+            // Cache directory path
+            'path' => storage_path('cache/api-data'),
+        ],
+    ]
 ];

--- a/config/vendor/cache.php
+++ b/config/vendor/cache.php
@@ -3,7 +3,7 @@
 return [
 
     // Whether to enable cache
-    // This setting is reflected when using ControlledCache
+    // This setting is reflected when using MemoCache
     'enabled' => (bool) env('CACHE_ENABLED', true),
 
     // Default lifetime seconds

--- a/modules/cache/config/cache.php
+++ b/modules/cache/config/cache.php
@@ -26,5 +26,6 @@ return [
     // This configuration is used to modify the dependencies for cache.
     'dependencies' => [
         // CmsTool\Cache\Contract\CacheItemPoolFactory::class => CmsTool\Cache\FilesystemCacheItemPoolFactory::class,
+        // CmsTool\Cache\Contract\MemoCache::class => CmsTool\Cache\PsrMemoCache::class
     ],
 ];

--- a/modules/cache/config/cache.php
+++ b/modules/cache/config/cache.php
@@ -3,7 +3,7 @@
 return [
 
     // Whether to enable cache
-    // This setting is reflected when using ControlledCache
+    // This setting is reflected when using MemoCache
     'enabled' => (bool) env('CACHE_ENABLED', true),
 
     // Default lifetime seconds

--- a/modules/cache/src/CacheProvider.php
+++ b/modules/cache/src/CacheProvider.php
@@ -4,6 +4,7 @@ namespace CmsTool\Cache;
 
 use CmsTool\Cache\Command\CacheCleanCommand;
 use CmsTool\Cache\Contract\CacheItemPoolFactory;
+use CmsTool\Cache\Contract\MemoCache;
 use Psr\Cache\CacheItemPoolInterface;
 use Takemo101\Chubby\ApplicationContainer;
 use Takemo101\Chubby\Bootstrap\Definitions;
@@ -35,6 +36,7 @@ class CacheProvider implements Provider
             ...ConfigBasedDefinitionReplacer::createDependencyDefinitions(
                 dependencies: [
                     CacheItemPoolFactory::class => FilesystemCacheItemPoolFactory::class,
+                    MemoCache::class => PsrMemoCache::class,
                 ],
                 configKeyPrefix: 'cache',
             )

--- a/modules/cache/src/Contract/CacheItemPoolFactory.php
+++ b/modules/cache/src/Contract/CacheItemPoolFactory.php
@@ -7,7 +7,8 @@ use Psr\Cache\CacheItemPoolInterface;
 interface CacheItemPoolFactory
 {
     /**
+     * @param array<string,mixed> $options Cache driver options
      * @return CacheItemPoolInterface
      */
-    public function create(): CacheItemPoolInterface;
+    public function create(array $options = []): CacheItemPoolInterface;
 }

--- a/modules/cache/src/Contract/MemoCache.php
+++ b/modules/cache/src/Contract/MemoCache.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace CmsTool\Cache\Contract;
+
+use Psr\Cache\CacheItemInterface;
+use InvalidArgumentException;
+
+/**
+ * Cache the result of a callback for a key.
+ */
+interface MemoCache
+{
+    /**
+     * If a cached value exists for the key, return that value.
+     * If it doesn't exist, cache and return the result of $callback().
+     *
+     * enabled = false, always return $callback()
+     *
+     * @template T
+     *
+     * @param string $key
+     * @param callable(CacheItemInterface):T $callback
+     * @param bool $enabled Whether to enable caching or not
+     * @return T
+     * @throws InvalidArgumentException If the $key string is not a legal value
+     */
+    public function get(
+        string $key,
+        callable $callback,
+        bool $enabled = true,
+    ): mixed;
+}

--- a/modules/cache/src/Contract/MemoCache.php
+++ b/modules/cache/src/Contract/MemoCache.php
@@ -2,6 +2,7 @@
 
 namespace CmsTool\Cache\Contract;
 
+use CmsTool\Cache\MemoCacheOptions;
 use Psr\Cache\CacheItemInterface;
 use InvalidArgumentException;
 
@@ -14,19 +15,19 @@ interface MemoCache
      * If a cached value exists for the key, return that value.
      * If it doesn't exist, cache and return the result of $callback().
      *
-     * enabled = false, always return $callback()
+     * options.enabled = false, always return $callback()
      *
      * @template T
      *
      * @param string $key
      * @param callable(CacheItemInterface):T $callback
-     * @param bool $enabled Whether to enable caching or not
+     * @param MemoCacheOptions|null $options Cache options
      * @return T
      * @throws InvalidArgumentException If the $key string is not a legal value
      */
     public function get(
         string $key,
         callable $callback,
-        bool $enabled = true,
+        ?MemoCacheOptions $options = null,
     ): mixed;
 }

--- a/modules/cache/src/Contract/MemoCache.php
+++ b/modules/cache/src/Contract/MemoCache.php
@@ -30,4 +30,12 @@ interface MemoCache
         callable $callback,
         ?MemoCacheOptions $options = null,
     ): mixed;
+
+    /**
+     * Remove the cache for the specified key.
+     *
+     * @param string $key
+     * @return boolean True if the cache was removed, false if it was not
+     */
+    public function forget(string $key): bool;
 }

--- a/modules/cache/src/Contract/MemoCache.php
+++ b/modules/cache/src/Contract/MemoCache.php
@@ -29,4 +29,11 @@ interface MemoCache
         callable $callback,
         bool $enabled = true,
     ): mixed;
+
+    /**
+     * Clear all cached values.
+     *
+     * @return void
+     */
+    public function clear(): void;
 }

--- a/modules/cache/src/Contract/MemoCache.php
+++ b/modules/cache/src/Contract/MemoCache.php
@@ -29,11 +29,4 @@ interface MemoCache
         callable $callback,
         bool $enabled = true,
     ): mixed;
-
-    /**
-     * Clear all cached values.
-     *
-     * @return void
-     */
-    public function clear(): void;
 }

--- a/modules/cache/src/FilesystemCacheItemPoolFactory.php
+++ b/modules/cache/src/FilesystemCacheItemPoolFactory.php
@@ -26,11 +26,14 @@ class FilesystemCacheItemPoolFactory implements CacheItemPoolFactory
     }
 
     /**
-     * @return CacheItemPoolInterface
+     * {@inheritDoc}
      */
-    public function create(): CacheItemPoolInterface
+    public function create(array $options = []): CacheItemPoolInterface
     {
-        $driver = new FileSystem($this->options);
+        $driver = new FileSystem([
+            ...$this->options,
+            ...$options,
+        ]);
 
         $pool = new Pool($driver);
 

--- a/modules/cache/src/MemoCacheOptions.php
+++ b/modules/cache/src/MemoCacheOptions.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace CmsTool\Cache;
+
+readonly class MemoCacheOptions
+{
+    /**
+     * constructor
+     *
+     * @param boolean|null $enabled Enable caching
+     * @param int<1,max>|null $lifetime Lifetime in seconds when caching is enabled
+     */
+    public function __construct(
+        public ?bool $enabled = null,
+        public ?int $lifetime = null,
+    ) {
+        //
+    }
+
+    /**
+     * Create options with caching enabled and a set lifetime.
+     *
+     * @param int<1,max> $lifetime Lifetime in seconds when caching is enabled
+     * @return self
+     */
+    public static function createWithLifetime(int $lifetime): self
+    {
+        return new self(
+            enabled: true,
+            lifetime: $lifetime,
+        );
+    }
+}

--- a/modules/cache/src/PsrMemoCache.php
+++ b/modules/cache/src/PsrMemoCache.php
@@ -64,4 +64,14 @@ class PsrMemoCache implements MemoCache
 
         return $value;
     }
+
+    /**
+     * Clear all cache items.
+     *
+     * @return boolean If the cache was cleared successfully, it returns true.
+     */
+    public function clear(): bool
+    {
+        return $this->pool->clear();
+    }
 }

--- a/modules/cache/src/PsrMemoCache.php
+++ b/modules/cache/src/PsrMemoCache.php
@@ -64,12 +64,4 @@ class PsrMemoCache implements MemoCache
 
         return $value;
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function clear(): void
-    {
-        $this->pool->clear();
-    }
 }

--- a/modules/cache/src/PsrMemoCache.php
+++ b/modules/cache/src/PsrMemoCache.php
@@ -2,12 +2,12 @@
 
 namespace CmsTool\Cache;
 
+use CmsTool\Cache\Contract\MemoCache;
 use DI\Attribute\Inject;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\CacheItemInterface;
-use InvalidArgumentException;
 
-class ControlledCache
+class PsrMemoCache implements MemoCache
 {
     /**
      * constructor
@@ -27,22 +27,22 @@ class ControlledCache
     }
 
     /**
-     * CacheItemPoolInterface wrapper
-     * enabled = false, always return $callback()
+     * {@inheritDoc}
      *
      * @template T
      *
      * @param string $key
      * @param callable(CacheItemInterface):T $callback
-     * @param bool $enabled default true
+     * @param bool $enabled Whether to enable caching or not
      * @return T
-     * @throws InvalidArgumentException
      */
     public function get(
         string $key,
         callable $callback,
         bool $enabled = true,
     ): mixed {
+        // If the base constructor flag is enabled, then enable the cache.
+        // Otherwise, enable the cache based on the argument flag.
         $enabled = $this->enabled && $enabled;
 
         $item = $this->pool->getItem($key);

--- a/modules/cache/src/PsrMemoCache.php
+++ b/modules/cache/src/PsrMemoCache.php
@@ -64,4 +64,12 @@ class PsrMemoCache implements MemoCache
 
         return $value;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clear(): void
+    {
+        $this->pool->clear();
+    }
 }

--- a/modules/cache/src/PsrMemoCache.php
+++ b/modules/cache/src/PsrMemoCache.php
@@ -67,6 +67,17 @@ class PsrMemoCache implements MemoCache
     }
 
     /**
+     * Remove the cache for the specified key.
+     *
+     * @param string $key
+     * @return boolean
+     */
+    public function forget(string $key): bool
+    {
+        return $this->pool->deleteItem($key);
+    }
+
+    /**
      * Clear all cache items.
      *
      * @return boolean If the cache was cleared successfully, it returns true.

--- a/modules/cache/src/SqliteCacheItemPoolFactory.php
+++ b/modules/cache/src/SqliteCacheItemPoolFactory.php
@@ -26,11 +26,14 @@ class SqliteCacheItemPoolFactory implements CacheItemPoolFactory
     }
 
     /**
-     * @return CacheItemPoolInterface
+     * {@inheritDoc}
      */
-    public function create(): CacheItemPoolInterface
+    public function create(array $options = []): CacheItemPoolInterface
     {
-        $driver = new Sqlite($this->options);
+        $driver = new Sqlite([
+            ...$this->options,
+            ...$options,
+        ]);
 
         $pool = new Pool($driver);
 

--- a/modules/cache/src/helper.php
+++ b/modules/cache/src/helper.php
@@ -1,6 +1,6 @@
 <?php
 
-use CmsTool\Cache\ControlledCache;
+use CmsTool\Cache\Contract\MemoCache;
 use Takemo101\Chubby\Support\ServiceLocator;
 use Psr\Cache\CacheItemInterface;
 
@@ -21,8 +21,8 @@ if (!function_exists('cache')) {
         callable $callback,
         bool $enabled = true,
     ): mixed {
-        /** @var ControlledCache */
-        $cache = ServiceLocator::container()->get(ControlledCache::class);
+        /** @var MemoCache */
+        $cache = ServiceLocator::container()->get(MemoCache::class);
 
         /** @var T */
         $value = $cache->get($key, $callback, $enabled);

--- a/modules/cache/src/helper.php
+++ b/modules/cache/src/helper.php
@@ -1,6 +1,7 @@
 <?php
 
 use CmsTool\Cache\Contract\MemoCache;
+use CmsTool\Cache\MemoCacheOptions;
 use Takemo101\Chubby\Support\ServiceLocator;
 use Psr\Cache\CacheItemInterface;
 
@@ -12,20 +13,20 @@ if (!function_exists('cache')) {
      *
      * @param string $key The key of the item to retrieve from the cache
      * @param callable(CacheItemInterface):T $callback The callable to execute if the item is not found in the cache
-     * @param bool $enabled default true
+     * @param ?MemoCacheOptions $options Cache options
      * @return T
      * @throws \InvalidArgumentException
      */
     function cache(
         string $key,
         callable $callback,
-        bool $enabled = true,
+        ?MemoCacheOptions $options = null,
     ): mixed {
         /** @var MemoCache */
         $cache = ServiceLocator::container()->get(MemoCache::class);
 
         /** @var T */
-        $value = $cache->get($key, $callback, $enabled);
+        $value = $cache->get($key, $callback, $options);
 
         return $value;
     }

--- a/modules/cache/tests/Cache/MemoCacheOptionsTest.php
+++ b/modules/cache/tests/Cache/MemoCacheOptionsTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use CmsTool\Cache\MemoCacheOptions;
+
+it('can create options with caching enabled and a set lifetime', function () {
+    $lifetime = 3600;
+    $options = MemoCacheOptions::createWithLifetime($lifetime);
+
+    expect($options->enabled)->toBeTrue();
+    expect($options->lifetime)->toBe($lifetime);
+})->group('MemoCacheOptions', 'cache');

--- a/modules/cache/tests/Cache/MemoCacheTest.php
+++ b/modules/cache/tests/Cache/MemoCacheTest.php
@@ -6,7 +6,7 @@ use Psr\Cache\CacheItemInterface;
 use Mockery as m;
 
 describe(
-    'ControlledCache',
+    'MemoCache',
     function () {
 
         it('should return cached value if enabled and item is hit', function () {
@@ -19,7 +19,7 @@ describe(
             $item->shouldReceive('isHit')->andReturn(true);
             $item->shouldReceive('get')->andReturn('cached value');
 
-            // Create an instance of ControlledCache
+            // Create an instance of MemoCache
             $cache = new PsrMemoCache($pool);
 
             // Define the callback function
@@ -46,7 +46,7 @@ describe(
             $item->shouldReceive('set');
             $pool->shouldReceive('save');
 
-            // Create an instance of ControlledCache
+            // Create an instance of MemoCache
             $cache = new PsrMemoCache($pool);
 
             // Define the callback function
@@ -72,7 +72,7 @@ describe(
             $item->shouldReceive('expiresAfter');
             $item->shouldReceive('set');
 
-            // Create an instance of ControlledCache with cache disabled
+            // Create an instance of MemoCache with cache disabled
             $cache = new PsrMemoCache($pool, false);
 
             // Define the callback function

--- a/modules/cache/tests/Cache/MemoCacheTest.php
+++ b/modules/cache/tests/Cache/MemoCacheTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use CmsTool\Cache\ControlledCache;
+use CmsTool\Cache\PsrMemoCache;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\CacheItemInterface;
 use Mockery as m;
@@ -20,7 +20,7 @@ describe(
             $item->shouldReceive('get')->andReturn('cached value');
 
             // Create an instance of ControlledCache
-            $cache = new ControlledCache($pool);
+            $cache = new PsrMemoCache($pool);
 
             // Define the callback function
             $callback = function (CacheItemInterface $item) {
@@ -47,7 +47,7 @@ describe(
             $pool->shouldReceive('save');
 
             // Create an instance of ControlledCache
-            $cache = new ControlledCache($pool);
+            $cache = new PsrMemoCache($pool);
 
             // Define the callback function
             $callback = function (CacheItemInterface $item) {
@@ -73,7 +73,7 @@ describe(
             $item->shouldReceive('set');
 
             // Create an instance of ControlledCache with cache disabled
-            $cache = new ControlledCache($pool, false);
+            $cache = new PsrMemoCache($pool, false);
 
             // Define the callback function
             $callback = function (CacheItemInterface $item) {
@@ -87,4 +87,4 @@ describe(
             expect($result)->toBe('callback value');
         });
     }
-)->group('ControlledCache', 'cache');
+)->group('MemoCache', 'cache');

--- a/modules/cache/tests/Cache/MemoCacheTest.php
+++ b/modules/cache/tests/Cache/MemoCacheTest.php
@@ -86,5 +86,18 @@ describe(
             // Assertions
             expect($result)->toBe('callback value');
         });
+
+        it('should clear the cache', function () {
+            // Create a mock for CacheItemPoolInterface
+            $pool = m::mock(CacheItemPoolInterface::class);
+
+            // Mock the clear method of CacheItemPoolInterface
+            $pool->shouldReceive('clear')->once();
+
+            // Create an instance of MemoCache with cache disabled
+            $cache = new PsrMemoCache($pool, false);
+
+            $cache->clear();
+        });
     }
 )->group('MemoCache', 'cache');

--- a/modules/cache/tests/Cache/MemoCacheTest.php
+++ b/modules/cache/tests/Cache/MemoCacheTest.php
@@ -86,18 +86,5 @@ describe(
             // Assertions
             expect($result)->toBe('callback value');
         });
-
-        it('should clear the cache', function () {
-            // Create a mock for CacheItemPoolInterface
-            $pool = m::mock(CacheItemPoolInterface::class);
-
-            // Mock the clear method of CacheItemPoolInterface
-            $pool->shouldReceive('clear')->once();
-
-            // Create an instance of MemoCache with cache disabled
-            $cache = new PsrMemoCache($pool, false);
-
-            $cache->clear();
-        });
     }
 )->group('MemoCache', 'cache');

--- a/modules/cache/tests/Cache/MemoCacheTest.php
+++ b/modules/cache/tests/Cache/MemoCacheTest.php
@@ -86,5 +86,18 @@ describe(
             // Assertions
             expect($result)->toBe('callback value');
         });
+
+        it('should clear the cache', function () {
+            // Create a mock for CacheItemPoolInterface
+            $pool = m::mock(CacheItemPoolInterface::class);
+
+            // Mock the clear method of CacheItemPoolInterface
+            $pool->shouldReceive('clear')->once()->andReturn(true);
+
+            // Create an instance of MemoCache with cache disabled
+            $cache = new PsrMemoCache($pool, false);
+
+            expect($cache->clear())->toBe(true);
+        });
     }
 )->group('MemoCache', 'cache');

--- a/modules/cache/tests/Cache/MemoCacheTest.php
+++ b/modules/cache/tests/Cache/MemoCacheTest.php
@@ -87,6 +87,26 @@ describe(
             expect($result)->toBe('callback value');
         });
 
+        it(
+            'should remove the cache for the specified key',
+            function () {
+                // Create a mock for CacheItemPoolInterface
+                $pool = m::mock(CacheItemPoolInterface::class);
+
+                // Mock the deleteItem method of CacheItemPoolInterface
+                $pool->shouldReceive('deleteItem')->once()->with('key')->andReturn(true);
+
+                // Create an instance of MemoCache
+                $cache = new PsrMemoCache($pool);
+
+                // Call the forget method
+                $result = $cache->forget('key');
+
+                // Assertions
+                expect($result)->toBe(true);
+            }
+        );
+
         it('should clear the cache', function () {
             // Create a mock for CacheItemPoolInterface
             $pool = m::mock(CacheItemPoolInterface::class);

--- a/src/Console/ApiCacheCleanCommand.php
+++ b/src/Console/ApiCacheCleanCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Takemo101\CmsTool\Console;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Output\OutputInterface;
+use Takemo101\Chubby\Console\Command\Command;
+use Takemo101\CmsTool\Infra\Cache\ApiMemoCache;
+
+#[AsCommand(
+    name: 'api-cache:clean',
+    description: "Clears the data cache",
+)]
+class ApiCacheCleanCommand extends Command
+{
+    /**
+     * Execute command process.
+     *
+     * @param OutputInterface $output
+     * @param ApiMemoCache $memo
+     * @return integer
+     */
+    public function handle(
+        OutputInterface $output,
+        ApiMemoCache $memo,
+    ) {
+        if ($memo->clear()) {
+            $output->writeln('<info>Cache cleared successfully.</info>');
+
+            return self::SUCCESS;
+        }
+
+        $output->writeln('<error>Failed to clear cache.</error>');
+
+        return self::FAILURE;
+    }
+}

--- a/src/Http/Controller/Admin/CacheController.php
+++ b/src/Http/Controller/Admin/CacheController.php
@@ -29,6 +29,7 @@ class CacheController
         ApiMemoCache $memo,
     ): ToastRenderer {
 
+        // If clearing the cache from the admin panel, it is recommended to use a webhook to clear only the API cache, as clearing the regular cache can affect more than just the frontend display.
         $cache->clear();
         $memo->clear();
 

--- a/src/Http/Controller/Admin/CacheController.php
+++ b/src/Http/Controller/Admin/CacheController.php
@@ -5,6 +5,7 @@ namespace Takemo101\CmsTool\Http\Controller\Admin;
 use CmsTool\View\View;
 use Psr\Cache\CacheItemPoolInterface;
 use Takemo101\CmsTool\Http\Renderer\RedirectBackRenderer;
+use Takemo101\CmsTool\Infra\Cache\ApiMemoCache;
 use Takemo101\CmsTool\Support\Toast\ToastRenderer;
 use Takemo101\CmsTool\Support\Toast\ToastStyle;
 
@@ -20,13 +21,16 @@ class CacheController
 
     /**
      * @param CacheItemPoolInterface $cache
+     * @param ApiMemoCache $memo
      * @return ToastRenderer<RedirectBackRenderer>
      */
     public function clean(
         CacheItemPoolInterface $cache,
+        ApiMemoCache $memo,
     ): ToastRenderer {
 
         $cache->clear();
+        $memo->clear();
 
         return toast(
             response: redirect()->back(),

--- a/src/Http/Controller/Admin/UninstallController.php
+++ b/src/Http/Controller/Admin/UninstallController.php
@@ -36,6 +36,7 @@ class UninstallController
 
         $handler->handle();
 
+        // When uninstalling, it is necessary to clear both the API cache and the regular cache as it deletes all data in the system.
         $cache->clear();
         $memo->clear();
 

--- a/src/Http/Controller/Admin/UninstallController.php
+++ b/src/Http/Controller/Admin/UninstallController.php
@@ -6,6 +6,7 @@ use CmsTool\View\View;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Takemo101\CmsTool\Http\Renderer\RedirectBackRenderer;
+use Takemo101\CmsTool\Infra\Cache\ApiMemoCache;
 use Takemo101\CmsTool\Infra\Event\Uninstalled;
 use Takemo101\CmsTool\Support\Toast\ToastRenderer;
 use Takemo101\CmsTool\Support\Toast\ToastStyle;
@@ -29,12 +30,14 @@ class UninstallController
         UninstallHandler $handler,
         AdminSession $session,
         CacheItemPoolInterface $cache,
+        ApiMemoCache $memo,
         EventDispatcherInterface $dispatcher
     ): ToastRenderer {
 
         $handler->handle();
 
         $cache->clear();
+        $memo->clear();
 
         $session->logout();
 

--- a/src/Infra/Cache/ApiMemoCache.php
+++ b/src/Infra/Cache/ApiMemoCache.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Takemo101\CmsTool\Infra\Cache;
+
+use CmsTool\Cache\Contract\MemoCache;
+
+interface ApiMemoCache extends MemoCache
+{
+    /**
+     * Clear all cache.
+     *
+     * @return boolean If the cache is cleared successfully, it returns true.
+     */
+    public function clear(): bool;
+}

--- a/src/Infra/Cache/FilesystemApiMemoCacheFactory.php
+++ b/src/Infra/Cache/FilesystemApiMemoCacheFactory.php
@@ -14,7 +14,7 @@ class FilesystemApiMemoCacheFactory
      * @param FilesystemCacheItemPoolFactory $factory
      * @param array<string,mixed> $options
      * @param boolean $enabled
-     * @param integer $lifetime
+     * @param int<1,max> $lifetime
      */
     public function __construct(
         private readonly FilesystemCacheItemPoolFactory $factory,
@@ -23,7 +23,7 @@ class FilesystemApiMemoCacheFactory
         #[Inject('config.system.api_cache.enabled')]
         private readonly bool $enabled = true,
         #[Inject('config.system.api_cache.lifetime')]
-        private readonly int $lifetime = 0,
+        private readonly int $lifetime = 21600,
     ) {
         //
     }

--- a/src/Infra/Cache/FilesystemApiMemoCacheFactory.php
+++ b/src/Infra/Cache/FilesystemApiMemoCacheFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Takemo101\CmsTool\Infra\Cache;
+
+use CmsTool\Cache\FilesystemCacheItemPoolFactory;
+use CmsTool\Cache\PsrMemoCache;
+use DI\Attribute\Inject;
+
+class FilesystemApiMemoCacheFactory
+{
+    /**
+     * constructor
+     *
+     * @param FilesystemCacheItemPoolFactory $factory
+     * @param array<string,mixed> $options
+     * @param boolean $enabled
+     * @param integer $lifetime
+     */
+    public function __construct(
+        private readonly FilesystemCacheItemPoolFactory $factory,
+        #[Inject('config.system.api_cache.filesystem')]
+        private readonly array $options = [],
+        #[Inject('config.system.api_cache.enabled')]
+        private readonly bool $enabled = true,
+        #[Inject('config.system.api_cache.lifetime')]
+        private readonly int $lifetime = 0,
+    ) {
+        //
+    }
+
+    /**
+     * Create a new instance of ApiMemoCache
+     *
+     * @return ApiMemoCache
+     */
+    public function create(): ApiMemoCache
+    {
+        $pool = new PsrMemoCache(
+            $this->factory->create($this->options),
+            $this->enabled,
+            $this->lifetime,
+        );
+
+        return new PsrApiMemoCache($pool);
+    }
+}

--- a/src/Infra/Cache/PsrApiMemoCache.php
+++ b/src/Infra/Cache/PsrApiMemoCache.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Takemo101\CmsTool\Infra\Cache;
+
+use CmsTool\Cache\PsrMemoCache;
+use Psr\Cache\CacheItemInterface;
+
+class PsrApiMemoCache implements ApiMemoCache
+{
+    /**
+     * constructor
+     *
+     * @param PsrMemoCache $memo
+     */
+    public function __construct(
+        private readonly PsrMemoCache $memo,
+    ) {
+        //
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @template T
+     *
+     * @param string $key
+     * @param callable(CacheItemInterface):T $callback
+     * @param bool $enabled Whether to enable caching or not
+     * @return T
+     */
+    public function get(
+        string $key,
+        callable $callback,
+        bool $enabled = true,
+    ): mixed {
+        return $this->memo->get(
+            key: $key,
+            callback: $callback,
+            enabled: $enabled,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clear(): bool
+    {
+        return $this->memo->clear();
+    }
+}

--- a/src/Infra/Cache/PsrApiMemoCache.php
+++ b/src/Infra/Cache/PsrApiMemoCache.php
@@ -2,6 +2,7 @@
 
 namespace Takemo101\CmsTool\Infra\Cache;
 
+use CmsTool\Cache\MemoCacheOptions;
 use CmsTool\Cache\PsrMemoCache;
 use Psr\Cache\CacheItemInterface;
 
@@ -25,18 +26,18 @@ class PsrApiMemoCache implements ApiMemoCache
      *
      * @param string $key
      * @param callable(CacheItemInterface):T $callback
-     * @param bool $enabled Whether to enable caching or not
+     * @param MemoCacheOptions|null $options Cache options
      * @return T
      */
     public function get(
         string $key,
         callable $callback,
-        bool $enabled = true,
+        ?MemoCacheOptions $options = null,
     ): mixed {
         return $this->memo->get(
             key: $key,
             callback: $callback,
-            enabled: $enabled,
+            options: $options,
         );
     }
 

--- a/src/Infra/Cache/PsrApiMemoCache.php
+++ b/src/Infra/Cache/PsrApiMemoCache.php
@@ -44,6 +44,14 @@ class PsrApiMemoCache implements ApiMemoCache
     /**
      * {@inheritDoc}
      */
+    public function forget(string $key): bool
+    {
+        return $this->memo->forget($key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function clear(): bool
     {
         return $this->memo->clear();

--- a/src/Infra/Listener/ClearCacheListener.php
+++ b/src/Infra/Listener/ClearCacheListener.php
@@ -28,6 +28,7 @@ class ClearCacheListener
      */
     public function __invoke(): void
     {
+        // If the theme is changed, both the API and regular cache need to be cleared as the presets for the theme will also change.
         $this->cache->clear();
         $this->memo->clear();
     }

--- a/src/Infra/Listener/ClearCacheListener.php
+++ b/src/Infra/Listener/ClearCacheListener.php
@@ -4,6 +4,7 @@ namespace Takemo101\CmsTool\Infra\Listener;
 
 use Psr\Cache\CacheItemPoolInterface;
 use Takemo101\Chubby\Event\Attribute\AsEventListener;
+use Takemo101\CmsTool\Infra\Cache\ApiMemoCache;
 use Takemo101\CmsTool\Infra\Event\ThemeActivated;
 
 #[AsEventListener(ThemeActivated::class)]
@@ -13,9 +14,11 @@ class ClearCacheListener
      * constructor
      *
      * @param CacheItemPoolInterface $cache
+     * @param ApiMemoCache $memo
      */
     public function __construct(
         private CacheItemPoolInterface $cache,
+        private ApiMemoCache $memo,
     ) {
         //
     }
@@ -26,5 +29,6 @@ class ClearCacheListener
     public function __invoke(): void
     {
         $this->cache->clear();
+        $this->memo->clear();
     }
 }

--- a/src/Infra/Saloon/QueryService/SaloonMicroCmsContentQueryService.php
+++ b/src/Infra/Saloon/QueryService/SaloonMicroCmsContentQueryService.php
@@ -15,7 +15,7 @@ use Takemo101\CmsTool\Infra\Shared\Exception\InfraException;
 use Takemo101\CmsTool\Support\ArrayObject\ImmutableArrayObjectable;
 use Takemo101\CmsTool\UseCase\Shared\QueryService\ContentPaginator;
 use Takemo101\CmsTool\UseCase\Shared\QueryService\Pager;
-use CmsTool\Cache\ControlledCache;
+use CmsTool\Cache\Contract\MemoCache;
 use Takemo101\CmsTool\Support\ArrayObject\ImmutableArrayObject;
 
 class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
@@ -24,11 +24,11 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
      * constructor
      *
      * @param MicroCmsApiConnectorFactory $factory
-     * @param ControlledCache $cache
+     * @param MemoCache $cache
      */
     public function __construct(
         private MicroCmsApiConnectorFactory $factory,
-        private ControlledCache $cache,
+        private MemoCache $cache,
     ) {
         //
     }
@@ -39,7 +39,6 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
     public function getSingle(
         string $endpoint,
         MicroCmsContentGetOneQuery $query = new MicroCmsContentGetOneQuery(),
-        bool $cache = true,
     ): ?ImmutableArrayObjectable {
 
         $apiQuery = new MicroCmsGetOneQuery(
@@ -73,8 +72,7 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
                 }
 
                 return $response->json();
-            },
-            enabled: $cache,
+            }
         );
 
         return empty($json)
@@ -120,7 +118,6 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
         string $endpoint,
         string $id,
         MicroCmsContentGetOneQuery $query = new MicroCmsContentGetOneQuery(),
-        bool $cache = true,
     ): ?ImmutableArrayObjectable {
 
         $apiQuery = new MicroCmsGetOneQuery(
@@ -158,7 +155,6 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
 
                 return $response->json();
             },
-            enabled: $cache,
         );
 
         return empty($json)
@@ -206,7 +202,6 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
     public function getFirst(
         string $endpoint,
         MicroCmsContentGetListQuery $query = new MicroCmsContentGetListQuery(),
-        bool $cache = true,
     ): ?ImmutableArrayObjectable {
 
         $apiQuery = new MicroCmsGetListQuery(
@@ -247,7 +242,6 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
 
                 return $response->json();
             },
-            enabled: $cache,
         );
 
         /** @var array<string,mixed>[] */
@@ -270,7 +264,6 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
         string $endpoint,
         Pager $pager = new Pager(),
         MicroCmsContentGetListQuery $query = new MicroCmsContentGetListQuery(),
-        bool $cache = true,
     ): MicroCmsContentGetListResult {
         $apiQuery = new MicroCmsGetListQuery(
             limit: $pager->limit,
@@ -311,7 +304,6 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
 
                 return $response->json();
             },
-            enabled: $cache,
         );
 
         /** @var array<string,mixed>[] */

--- a/src/Infra/Saloon/QueryService/SaloonMicroCmsContentQueryService.php
+++ b/src/Infra/Saloon/QueryService/SaloonMicroCmsContentQueryService.php
@@ -15,7 +15,7 @@ use Takemo101\CmsTool\Infra\Shared\Exception\InfraException;
 use Takemo101\CmsTool\Support\ArrayObject\ImmutableArrayObjectable;
 use Takemo101\CmsTool\UseCase\Shared\QueryService\ContentPaginator;
 use Takemo101\CmsTool\UseCase\Shared\QueryService\Pager;
-use CmsTool\Cache\Contract\MemoCache;
+use Takemo101\CmsTool\Infra\Cache\ApiMemoCache;
 use Takemo101\CmsTool\Support\ArrayObject\ImmutableArrayObject;
 
 class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
@@ -24,11 +24,11 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
      * constructor
      *
      * @param MicroCmsApiConnectorFactory $factory
-     * @param MemoCache $cache
+     * @param ApiMemoCache $memo
      */
     public function __construct(
         private MicroCmsApiConnectorFactory $factory,
-        private MemoCache $cache,
+        private ApiMemoCache $memo,
     ) {
         //
     }
@@ -52,7 +52,7 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
         ]);
 
         /** @var array<string,mixed> */
-        $json = $this->cache->get(
+        $json = $this->memo->get(
             key: $key,
             callback: function () use (
                 $endpoint,
@@ -132,7 +132,7 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
         ]);
 
         /** @var array<string,mixed> */
-        $json = $this->cache->get(
+        $json = $this->memo->get(
             key: $key,
             callback: function () use (
                 $endpoint,
@@ -220,7 +220,7 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
         ]);
 
         /** @var array<string,mixed> */
-        $json = $this->cache->get(
+        $json = $this->memo->get(
             key: $key,
             callback: function () use (
                 $endpoint,
@@ -282,7 +282,7 @@ class SaloonMicroCmsContentQueryService implements MicroCmsContentQueryService
         ]);
 
         /** @var array<string,mixed> */
-        $json = $this->cache->get(
+        $json = $this->memo->get(
             key: $key,
             callback: function () use (
                 $endpoint,

--- a/src/Support/Webhook/CacheCleanWebhookHandler.php
+++ b/src/Support/Webhook/CacheCleanWebhookHandler.php
@@ -2,7 +2,6 @@
 
 namespace Takemo101\CmsTool\Support\Webhook;
 
-use Psr\Cache\CacheItemPoolInterface;
 use Takemo101\CmsTool\Infra\Cache\ApiMemoCache;
 
 class CacheCleanWebhookHandler implements WebhookHandler
@@ -10,11 +9,9 @@ class CacheCleanWebhookHandler implements WebhookHandler
     /**
      * constructor
      *
-     * @param CacheItemPoolInterface $cache
      * @param ApiMemoCache $memo
      */
     public function __construct(
-        private CacheItemPoolInterface $cache,
         private ApiMemoCache $memo,
     ) {
         //
@@ -25,7 +22,7 @@ class CacheCleanWebhookHandler implements WebhookHandler
      */
     public function handle(array $payload): void
     {
-        $this->cache->clear();
+        // When the webhook is triggered, only the content displayed on the front end needs to be updated, so we need to clear the cache for the API only.
         $this->memo->clear();
     }
 }

--- a/src/Support/Webhook/CacheCleanWebhookHandler.php
+++ b/src/Support/Webhook/CacheCleanWebhookHandler.php
@@ -3,6 +3,7 @@
 namespace Takemo101\CmsTool\Support\Webhook;
 
 use Psr\Cache\CacheItemPoolInterface;
+use Takemo101\CmsTool\Infra\Cache\ApiMemoCache;
 
 class CacheCleanWebhookHandler implements WebhookHandler
 {
@@ -10,9 +11,11 @@ class CacheCleanWebhookHandler implements WebhookHandler
      * constructor
      *
      * @param CacheItemPoolInterface $cache
+     * @param ApiMemoCache $memo
      */
     public function __construct(
         private CacheItemPoolInterface $cache,
+        private ApiMemoCache $memo,
     ) {
         //
     }
@@ -23,5 +26,6 @@ class CacheCleanWebhookHandler implements WebhookHandler
     public function handle(array $payload): void
     {
         $this->cache->clear();
+        $this->memo->clear();
     }
 }

--- a/src/Support/Webhook/WebhookHandlingExceptions.php
+++ b/src/Support/Webhook/WebhookHandlingExceptions.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Takemo101\CmsTool\Support\Webhook;
+
+use Takemo101\Chubby\Exception\Exceptions;
+use Throwable;
+
+/**
+ * Exception for handling multiple exceptions that occurred in webhook handlers.
+ */
+class WebhookHandlingExceptions extends Exceptions
+{
+    public const Message = 'Multiple exceptions occurred in webhook handlers';
+
+    /**
+     * Throw if the given exceptions are not empty.
+     *
+     * @param Throwable ...$throwables The exceptions that occurred.
+     * @return void|never
+     */
+    public static function throwIfNotEmpty(Throwable ...$throwables): void
+    {
+        if (empty($throwables)) {
+            return;
+        }
+
+        throw new static(...$throwables);
+    }
+}

--- a/src/UseCase/MicroCms/QueryService/Content/MicroCmsContentQueryService.php
+++ b/src/UseCase/MicroCms/QueryService/Content/MicroCmsContentQueryService.php
@@ -12,13 +12,11 @@ interface MicroCmsContentQueryService
      *
      * @param string $endpoint
      * @param MicroCmsContentGetOneQuery $query
-     * @param bool $cache
      * @return ImmutableArrayObjectable<string,mixed>|null
      */
     public function getSingle(
         string $endpoint,
         MicroCmsContentGetOneQuery $query = new MicroCmsContentGetOneQuery(),
-        bool $cache = true,
     ): ?ImmutableArrayObjectable;
 
     /**
@@ -42,14 +40,12 @@ interface MicroCmsContentQueryService
      * @param string $endpoint
      * @param string $id
      * @param MicroCmsContentGetOneQuery $query
-     * @param bool $cache
      * @return ImmutableArrayObjectable<string,mixed>|null
      */
     public function getOne(
         string $endpoint,
         string $id,
         MicroCmsContentGetOneQuery $query = new MicroCmsContentGetOneQuery(),
-        bool $cache = true,
     ): ?ImmutableArrayObjectable;
 
     /**
@@ -73,13 +69,11 @@ interface MicroCmsContentQueryService
      *
      * @param string $endpoint
      * @param MicroCmsContentGetListQuery $query
-     * @param bool $cache
      * @return ImmutableArrayObjectable<string,mixed>|null
      */
     public function getFirst(
         string $endpoint,
         MicroCmsContentGetListQuery $query = new MicroCmsContentGetListQuery(),
-        bool $cache = true,
     ): ?ImmutableArrayObjectable;
 
     /**
@@ -88,13 +82,11 @@ interface MicroCmsContentQueryService
      * @param string $endpoint
      * @param Pager $pager
      * @param MicroCmsContentGetListQuery $query
-     * @param bool $cache
      * @return MicroCmsContentGetListResult
      */
     public function getList(
         string $endpoint,
         Pager $pager = new Pager(),
         MicroCmsContentGetListQuery $query = new MicroCmsContentGetListQuery(),
-        bool $cache = true,
     ): MicroCmsContentGetListResult;
 }

--- a/src/dependency.php
+++ b/src/dependency.php
@@ -12,6 +12,8 @@ use Takemo101\CmsTool\Domain\SiteMeta\SiteMetaRepository;
 use Takemo101\CmsTool\Domain\Theme\ActiveThemeRepository;
 use Takemo101\CmsTool\Domain\Tracking\TrackingCodeRepository;
 use Takemo101\CmsTool\Domain\Webhook\WebhookTokenRepository;
+use Takemo101\CmsTool\Infra\Cache\ApiMemoCache;
+use Takemo101\CmsTool\Infra\Cache\FilesystemApiMemoCacheFactory;
 use Takemo101\CmsTool\Infra\Cache\PsrThemeCustomizationTemporaryCache;
 use Takemo101\CmsTool\Infra\Hash\DefaultPasswordHasher;
 use Takemo101\CmsTool\Infra\JsonAccess\QueryService\JsonAccessAdminAccountQueryService;
@@ -42,6 +44,7 @@ use Takemo101\CmsTool\UseCase\Theme\Support\ThemeCustomizationTemporaryCache;
 use Takemo101\CmsTool\UseCase\TrackingCode\QueryService\TrackingCodeQueryService;
 
 use function DI\get;
+use function DI\factory;
 
 return [
     // Repository
@@ -71,4 +74,6 @@ return [
 
     Installer::class => get(JsonAccessInstaller::class),
     Uninstaller::class => get(JsonAccessUninstaller::class),
+
+    ApiMemoCache::class => factory([FilesystemApiMemoCacheFactory::class, 'create']),
 ];

--- a/src/function.php
+++ b/src/function.php
@@ -12,6 +12,7 @@ use Takemo101\Chubby\Event\EventRegister;
 use Takemo101\Chubby\Http\ErrorHandler\ErrorResponseRenders;
 use Takemo101\Chubby\Http\SlimHttp;
 use Takemo101\Chubby\Support\ApplicationSummary;
+use Takemo101\CmsTool\Console\ApiCacheCleanCommand;
 use Takemo101\CmsTool\Console\GenerateBasicAuthPasswordCommand;
 use Takemo101\CmsTool\Console\StorageLinkCommand;
 use Takemo101\CmsTool\Error\SystemErrorPageRender;
@@ -64,6 +65,7 @@ hook()
         fn (CommandCollection $commands) => $commands->add(
             StorageLinkCommand::class,
             GenerateBasicAuthPasswordCommand::class,
+            ApiCacheCleanCommand::class,
         ),
     )
     ->onTyped(


### PR DESCRIPTION
## 概要

Apiデータとその他データのキャッシュを別々に管理できていなかったため、記事データ作成/更新時にApiデータのキャッシュのみをクリアすることができませんでした。

上記の問題を解決するため、Apiデータとその他汎データのキャッシュを種類別に管理できるように、キャッシュクラスを分けました。

## 変更内容

1. ``ControlledCache``を``MemoCache``という名前に変更
2. ``MemoCache``を拡張した``ApiMemoCache``というキャッシュクラスを追加
3. 記事の作成/更新などのアクション時にトリガーされるウェブフックで、Apiデータのキャッシュのみをクリアするように修正

## 備考
``config/cache.php``と``config/system.php``のコンフィグファイルを変更したので、システムをアップデートする場合はコンフィグを修正するのを忘れないでください。
